### PR TITLE
Add build to Travis to catch more errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
 cache:
   directories:
   - "~/.npm"
+before_script:
+  - npm i -g gatsby
 script:
 - npm run lint
 - npm run test
+after_success:
+- npm run build

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ down: ## stop and remove learner-portal container
 	docker-compose down
 
 npm-install-%: ## install specified % npm package on the learner-portal container
-	docker exec npm install $* --save-dev
+	docker exec frontend-app-learner-portal_web_1 npm install $* --save-dev
 	git add package.json
 
 restart:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ down: ## stop and remove learner-portal container
 	docker-compose down
 
 npm-install-%: ## install specified % npm package on the learner-portal container
-	docker exec frontend-app-learner-portal_web_1 npm install $* --save-dev
+	docker exec npm install $* --save-dev
 	git add package.json
 
 restart:


### PR DESCRIPTION
My only concern with this is the Gatsby cache breaking. I'm not sure what travis caches, or how they would interact, but I suppose if it becomes a problem we could also add a `clean` step.