### PR TITLE
Fix travis to report build errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: node_js
 node_js:
-- 8.9.3
+  - 8.9.3
 cache:
   directories:
-  - "~/.npm"
+    - "~/.npm"
 before_script:
   - npm i -g gatsby
 script:
-- npm run lint
-- npm run test
-after_success:
-- npm run build
+  - npm run lint
+  - npm run test
+  - npm run build


### PR DESCRIPTION
Travis was doing the build step after success, which means it wasn't reporting the build errors properly (whoops!).