### PR TITLE
Create DashboardHome and CourseSection components

### DIFF
--- a/src/components/CourseSection/CourseSection.jsx
+++ b/src/components/CourseSection/CourseSection.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const CourseSection = (props) => {
+  const { component: Component, enrollments, title } = props;
+
+  if (enrollments.length > 0) {
+    return (
+      <div className="course-section">
+        <h2 className="mb-4">{title}</h2>
+        {enrollments.map((courseData) => {
+          const { status } = courseData;
+          const defaultCardProps = {
+            title: courseData.display_name,
+            microMastersTitle: courseData.micromasters_title,
+          };
+          const cardProps = {};
+          switch (status) {
+            case 'in-progress':
+              cardProps.endDate = courseData.end_date;
+              cardProps.linkToCourse = courseData.resume_course_run_url;
+              break;
+            case 'upcoming':
+              cardProps.startDate = courseData.start_date;
+              cardProps.linkToCourse = courseData.course_run_url;
+              break;
+            case 'completed':
+              cardProps.endDate = courseData.end_date;
+              cardProps.linkToCourse = courseData.course_run_url;
+              break;
+            default:
+              break;
+          }
+          return <Component {...defaultCardProps} {...cardProps} />;
+        })}
+      </div>
+    );
+  }
+
+  return null;
+};
+
+CourseSection.propTypes = {
+  component: PropTypes.element.isRequired,
+  enrollments: PropTypes.arrayOf(PropTypes.shape({
+    display_name: PropTypes.string.isRequired,
+    micromasters_title: PropTypes.string,
+    start_date: PropTypes.string,
+    end_date: PropTypes.string,
+    resume_course_run_url: PropTypes.string,
+    course_run_url: PropTypes.string,
+  })).isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+export default CourseSection;

--- a/src/components/DashboardHome/DashboardHome.jsx
+++ b/src/components/DashboardHome/DashboardHome.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+
+import Hero from '../Hero/Hero';
+import CourseSection from '../CourseSection/CourseSection';
+import InProgressCourseCard from '../CourseCard/InProgressCourseCard';
+import UpcomingCourseCard from '../CourseCard/UpcomingCourseCard';
+import CompletedCourseCard from '../CourseCard/CompletedCourseCard';
+
+import sampleApiResponse from './sampleApiResponse';
+
+import './DashboardHome.scss';
+
+class DashboardHome extends React.Component {
+  state = {
+    courses: {
+      'in-progress': [],
+      upcoming: [],
+      completed: [],
+    },
+    // Temporarily adds `isProgramEnrollmentsLoading` to state to simulate loading
+    // state. Once we are actually calling the API and have Redux set up, this should
+    // come from props instead of state.
+    isProgramEnrollmentsLoading: true,
+  };
+
+  componentDidMount() {
+    this.groupCourseEnrollmentsByStatus();
+
+    // Temporarily simulate loading by resetting `isProgramEnrollmentsLoading` to false
+    // after 2 seconds.
+    setTimeout(() => {
+      this.setState({
+        isProgramEnrollmentsLoading: false,
+      });
+    }, 2000);
+  }
+
+  groupCourseEnrollmentsByStatus = () => {
+    const { course_runs: courseRuns } = sampleApiResponse;
+
+    this.setState({
+      courses: {
+        'in-progress': courseRuns.filter(courseRun => courseRun.status === 'in-progress'),
+        upcoming: courseRuns.filter(courseRun => courseRun.status === 'upcoming'),
+        completed: courseRuns.filter(courseRun => courseRun.status === 'completed'),
+      },
+    });
+  }
+
+  render() {
+    const { courses, isProgramEnrollmentsLoading } = this.state;
+
+    return (
+      <>
+        <Hero
+          programTitle="Master's Degree in Analytics"
+          organizationLogo={{
+            url: 'https://www.edx.org/sites/default/files/school/image/logo/gtx-logo-200x101.png',
+            alt: 'Georgia Tech Institute of Technology logo',
+          }}
+          textureImage="https://prod-discovery.edx-cdn.org/media/degree_marketing/campus_images/gt-cyber-title_bg_img_440x400.jpg"
+          coverImage="https://prod-discovery.edx-cdn.org/media/degree_marketing/campus_images/gt_cyber_campus_image_1000x400.jpg"
+        />
+        <div className="container py-5">
+          <div className="row">
+            <div className="col-xs-12 col-lg-8">
+              {isProgramEnrollmentsLoading ? (
+                <div className="d-flex justify-content-center align-items-center">
+                  <div className="spinner-border text-primary" role="status">
+                    <div className="sr-only">Loading program enrollments...</div>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <CourseSection
+                    title="My Courses In Progress"
+                    component={InProgressCourseCard}
+                    enrollments={courses['in-progress']}
+                  />
+                  <CourseSection
+                    title="Upcoming Courses"
+                    component={UpcomingCourseCard}
+                    enrollments={courses.upcoming}
+                  />
+                  <CourseSection
+                    title="Completed Courses"
+                    component={CompletedCourseCard}
+                    enrollments={courses.completed}
+                  />
+                </>
+              )}
+            </div>
+            <div className="col">
+              <p>Sidebar Content</p>
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+export default DashboardHome;

--- a/src/components/DashboardHome/DashboardHome.scss
+++ b/src/components/DashboardHome/DashboardHome.scss
@@ -1,0 +1,12 @@
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/utilities/_spacing";
+
+.course-section {
+  @extend .mb-5;
+
+  &:last-child {
+    @extend .mb-0;
+  }
+}

--- a/src/components/DashboardHome/sampleApiResponse.js
+++ b/src/components/DashboardHome/sampleApiResponse.js
@@ -1,0 +1,53 @@
+/*
+ * The `DashboardHome` component will likely handle the fetching of
+ * the program course enrollments data for the logged in learner. This
+ * endpoint is still in development. For the time being, we are including
+ * a sample API response here.
+ *
+ * TODO: Get this response from the API endpoint!
+ */
+const sampleApiResponse = {
+  course_runs: [
+    {
+      course_run_id: 'edX+DemoX+Demo_Course',
+      display_name: 'edX Demonstration Course',
+      resume_course_run_url: 'https://edx.org/',
+      course_run_url: 'https://edx.org/',
+      start_date: '2017-02-05T05:00:00Z',
+      end_date: '2019-06-10T05:00:00Z',
+      emails_enabled: true,
+      upcoming_dates: [],
+      micromasters_title: null,
+      certificate_generation_url: null,
+      status: 'in-progress',
+    },
+    {
+      course_run_id: 'edX+DemoX+Demo_Course',
+      display_name: 'edX Demonstration Course',
+      resume_course_run_url: 'https://edx.org/',
+      course_run_url: 'https://edx.org/',
+      start_date: '2017-02-05T05:00:00Z',
+      end_date: '2018-02-05T05:00:00Z',
+      emails_enabled: true,
+      upcoming_dates: [],
+      micromasters_title: 'MicroMasters® Program in Analytics: Essential Tools and Methods',
+      certificate_generation_url: null,
+      status: 'completed',
+    },
+    {
+      course_run_id: 'edX+DemoX+Demo_Course',
+      display_name: 'edX Demonstration Course',
+      resume_course_run_url: 'https://edx.org/',
+      course_run_url: 'https://edx.org/',
+      start_date: '2019-07-01T05:00:00Z',
+      end_date: '2019-12-31T05:00:00Z',
+      emails_enabled: true,
+      upcoming_dates: [],
+      micromasters_title: null,
+      certificate_generation_url: null,
+      status: 'upcoming',
+    },
+  ],
+};
+
+export default sampleApiResponse;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -4,10 +4,7 @@ import { library } from '@fortawesome/fontawesome-svg-core';
 import { fas } from '@fortawesome/free-solid-svg-icons';
 
 import Layout from '../components/Layout/Layout';
-import Hero from '../components/Hero/Hero';
-import InProgressCourseCard from '../components/CourseCard/InProgressCourseCard';
-import UpcomingCourseCard from '../components/CourseCard/UpcomingCourseCard';
-import CompletedCourseCard from '../components/CourseCard/CompletedCourseCard';
+import DashboardHome from '../components/DashboardHome/DashboardHome';
 
 // Add icons to font-awesome library
 library.add(fas);
@@ -15,55 +12,7 @@ library.add(fas);
 const IndexPage = () => (
   <IntlProvider locale="en">
     <Layout>
-      <Hero
-        programTitle="Master's Degree in Analytics"
-        organizationLogo={{
-          url: 'https://www.edx.org/sites/default/files/school/image/logo/gtx-logo-200x101.png',
-          alt: 'Georgia Tech Institute of Technology logo',
-        }}
-        textureImage="https://prod-discovery.edx-cdn.org/media/degree_marketing/campus_images/gt-cyber-title_bg_img_440x400.jpg"
-        coverImage="https://prod-discovery.edx-cdn.org/media/degree_marketing/campus_images/gt_cyber_campus_image_1000x400.jpg"
-      />
-      <div className="container py-5">
-        <div className="row">
-          <div className="col-xs-12 col-lg-8">
-            <div className="mb-5">
-              <h2 className="mb-4">My Courses In Progress</h2>
-              <InProgressCourseCard
-                title="Advanced Analytics Thinking"
-                endDate="2019-11-03"
-                linkToCourse="https://edx.org"
-              />
-              <InProgressCourseCard
-                title="Statistics for Analyics"
-                endDate="2019-07-23"
-                linkToCourse="https://edx.org"
-                microMastersTitle="MicroMasters&reg; Program in Analytics: Essential Tools and Methods"
-              />
-            </div>
-            <div className="mb-5">
-              <h2 className="mb-4">Upcoming Courses</h2>
-              <UpcomingCourseCard
-                title="Predictive Analytics with Spark"
-                startDate="2019-04-29"
-                linkToCourse="https://edx.org"
-              />
-            </div>
-            <div>
-              <h2 className="mb-4">Completed Courses</h2>
-              <CompletedCourseCard
-                title="Big Data and How To Use It"
-                endDate="2019-03-08"
-                linkToCourse="https://edx.org"
-                grade={{ hasPassed: true, numericGrade: 0.97 }}
-              />
-            </div>
-          </div>
-          <div className="col">
-            Sidebar Content
-          </div>
-        </div>
-      </div>
+      <DashboardHome />
     </Layout>
   </IntlProvider>
 );


### PR DESCRIPTION
[ENT-1816](https://openedx.atlassian.net/browse/ENT-1816)

This PR accomplishes the following:
1. Adds a `<DashboardHome>` component that contains the hero, main content, and sidebar areas. It is a child of the `<Layout>` component in `pages/index.jsx`.
2. Creates a new file `sampleApiResponse.js` that contains a sample API response that matches the format in the document that was shared earlier. The `DashboardHome` component reads from this file, and groups enrollments by status ('in-progress', 'upcoming', or 'completed'), which is what we will expect from the API endpoint.
3. Simulates the loading state while waiting for the API response by including a spinner (the one used on the new profile MFE) in the main content area.
4. Adds a `CourseSection` component that renders each course section ("In Progress", "Upcoming", "Completed") and its associated course cards. If a course section has 0 enrollments, the section should not be rendered.

**Note:** This PR does not include tests yet; because this change (e.g., the `DashboardHome` component) will need to be used in other branches, I'd like to get this merged sooner than later to avoid potential conflicts. I will come back to adding tests later in a separate PR.

**Note:** The UI mocks show that the course sections can be collapsed/expanded. I'd like to use the `Collapsible` component from Paragon but it will need some updating to get the styles we want. I am holding off on the collapsible functionality in this PR and will come back to that later as well.