### PR TITLE
Email Settings Modal PR Feedback

### DIFF
--- a/src/components/CourseCard/BaseCourseCard.jsx
+++ b/src/components/CourseCard/BaseCourseCard.jsx
@@ -3,53 +3,55 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import moment from 'moment';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-
-import './CourseCard.scss';
+import { StatusAlert } from '@edx/paragon';
 
 import EmailSettingsModal from './EmailSettingsModal';
+
+import './CourseCard.scss';
 
 class BaseCourseCard extends Component {
   state = {
     modals: {
-      email_settings: null,
+      emailSettings: null,
     },
+    hasEmailsEnabled: this.props.hasEmailSettings || false,
+    hasNewEmailSettings: false,
   };
 
   setModalState = ({ key, options }) => {
-    this.setState({
+    this.setState(state => ({
       modals: {
-        ...this.state.modals,
+        ...state.modals,
         [key]: options,
       },
-    });
+    }));
+  };
+
+  handleEmailSettingsModalOnClose = (hasEmailsEnabled) => {
+    this.resetModals();
+
+    if (hasEmailsEnabled !== undefined) {
+      this.setState({
+        hasNewEmailSettings: true,
+        hasEmailsEnabled,
+      });
+    }
   };
 
   resetModals = () => {
     this.setState({
       modals: {
-        email_settings: null,
+        emailSettings: null,
       },
     });
-  };
-
-  handleEmailSettingsChange = () => {
-    this.setModalState({
-      key: 'email_settings',
-      options: {
-        ...this.state.modals.email_settings,
-        submitting: true,
-      },
-    });
-
-    // Dispatch email settings change action here.
-    console.log('Changing Email settings.', this.state);
   };
 
   render() {
     const {
       modals,
+      hasEmailsEnabled,
+      hasNewEmailSettings,
     } = this.state;
-
     const {
       children,
       title,
@@ -93,32 +95,57 @@ class BaseCourseCard extends Component {
           </div>
           {children && children}
           {hasEmailSettings && (
-            <div className="row no-gutters">
-              <button
-                className="btn btn-link p-0"
-                onClick={() => this.setModalState({
-                  key: 'email_settings',
-                  options: {
-                    title: `Email Settings for '${title}'`,
-                    submitting: false,
-                    data: {
-                      course: linkToCourse,
-                    },
-                  },
-                  })}
-              >
-                <FontAwesomeIcon className="mr-2" icon={['fas', 'cog']} />
-                Email settings
-              </button>
-              {
-                modals.email_settings &&
-                <EmailSettingsModal
-                  {...modals.email_settings}
-                  onEmailSettingsChange={this.handleEmailSettingsChange}
-                  onClose={this.resetModals}
-                />
+            <>
+              {hasNewEmailSettings &&
+                <div className="row no-gutters">
+                  <div className="col-xs-12 col-sm-10 col-md-8">
+                    <StatusAlert
+                      alertType="success"
+                      dialog={
+                        <>
+                          <FontAwesomeIcon className="mr-2" icon={['fas', 'check-circle']} />
+                          Your email settings have been saved.
+                        </>
+                      }
+                      onClose={() => {
+                        this.setState({
+                          hasNewEmailSettings: false,
+                        });
+                      }}
+                      open
+                    />
+                  </div>
+                </div>
               }
-            </div>
+              <div className="row no-gutters">
+                <div className="col">
+                  <button
+                    className="btn btn-link p-0"
+                    onClick={() => {
+                      this.setModalState({
+                        key: 'emailSettings',
+                        options: {
+                          title,
+                          hasEmailsEnabled,
+                        },
+                      });
+                      this.setState({
+                        hasNewEmailSettings: false,
+                      });
+                    }}
+                  >
+                    <FontAwesomeIcon className="mr-2" icon={['fas', 'cog']} />
+                    Email settings
+                  </button>
+                  {modals.emailSettings &&
+                    <EmailSettingsModal
+                      {...modals.emailSettings}
+                      onClose={this.handleEmailSettingsModalOnClose}
+                    />
+                  }
+                </div>
+              </div>
+            </>
           )}
         </div>
       </div>
@@ -133,6 +160,7 @@ BaseCourseCard.propTypes = {
   children: PropTypes.node,
   startDate: PropTypes.string,
   endDate: PropTypes.string,
+  hasEmailsEnabled: PropTypes.bool,
   hasEmailSettings: PropTypes.bool,
   microMastersTitle: PropTypes.string,
 };
@@ -142,6 +170,7 @@ BaseCourseCard.defaultProps = {
   children: null,
   startDate: null,
   endDate: null,
+  hasEmailsEnabled: false,
   hasEmailSettings: true,
   microMastersTitle: null,
 };

--- a/src/components/CourseCard/EmailSettingsModal.jsx
+++ b/src/components/CourseCard/EmailSettingsModal.jsx
@@ -1,57 +1,138 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {Button, CheckBox, Icon, Modal} from '@edx/paragon';
+import { Input, Modal, StatusAlert } from '@edx/paragon';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import './EmailSettingsModal.scss';
 
+class EmailSettingsModal extends Component {
+  state = {
+    hasEmailsEnabled: this.props.hasEmailsEnabled || false,
+    isSubmitting: false,
+    isFormChanged: false,
+    error: null,
+  };
 
-const EmailSettingsModal = (props) => {
-  const modalRef = React.createRef();
-  const {
-    title, submitting, onClose, onEmailSettingsChange,
-  } = props;
+  handleEmailSettingsChange = (e) => {
+    const { hasEmailsEnabled } = this.props;
+    const isChecked = e.target.checked;
+    this.setState({
+      isFormChanged: isChecked !== hasEmailsEnabled,
+      hasEmailsEnabled: isChecked,
+    });
+  };
 
-  return (
-    <React.Fragment>
-      <Modal
-        ref={modalRef}
-        title={title}
-        body={
-          <React.Fragment>
-            <CheckBox
-              name="email_settings"
-              label={
-                <React.Fragment>
-                  <span>
-                    Receive course emails such as reminders, schedule updates,
-                    and other critical announcements.
-                  </span>
-                  &nbsp; &nbsp;
-                  {submitting && <Icon className={['fa', 'fa-spinner', 'fa-spin', 'mr-2']} />}
-                </React.Fragment>
-              }
-              disabled={submitting}
-              onChange={onEmailSettingsChange}
-            />
-          </React.Fragment>
-        }
-        onClose={onClose}
-        closeText={submitting ? <Icon className={['fa', 'fa-spinner', 'fa-spin', 'mr-2']} /> : 'Save Settings'}
-        open
-      />
-    </React.Fragment>
-  );
-};
+  handleSaveButtonClick = () => {
+    const { hasEmailsEnabled } = this.state;
+    // TODO: Make API POST request to set the new email settings.
+    this.setState({
+      isSubmitting: true,
+    }, () => {
+      /* This callback function simulates an API call to save the
+       * new email settings. There are lines below to either
+       * resolve (200 response) or reject the promise (error response). To
+       * see what happens when the promise is rejected, switch the comments.
+       */
 
-EmailSettingsModal.defaultProps = {
-  submitting: false,
-};
+      // eslint-disable-next-line no-unused-vars
+      new Promise((resolve, reject) => {
+        setTimeout(resolve, 2000);
+        // setTimeout(() => reject(new Error('Network Error')), 2000);
+      })
+        .then(() => {
+          this.props.onClose(hasEmailsEnabled);
+        })
+        .catch((error) => {
+          this.setState({
+            isSubmitting: false,
+            error,
+          });
+        });
+    });
+  };
+
+  handleOnClose = () => {
+    this.setState({
+      isSubmitting: false,
+      isFormChanged: false,
+      error: null,
+    });
+    this.props.onClose();
+  };
+
+  render() {
+    const {
+      error, isFormChanged, hasEmailsEnabled, isSubmitting,
+    } = this.state;
+    const { title } = this.props;
+
+    return (
+      <>
+        <Modal
+          title={`Email Settings for ${title}`}
+          body={
+            <>
+              {error && (
+                <StatusAlert
+                  alertType="danger"
+                  dialog={
+                    <div className="d-flex">
+                      <div>
+                        <FontAwesomeIcon className="mr-3" icon={['fas', 'exclamation-triangle']} />
+                      </div>
+                      <div>
+                        An error occurred while saving your email settings. Please try again.
+                      </div>
+                    </div>
+                  }
+                  dismissible={false}
+                  open
+                />
+              )}
+              <div className="form-check">
+                <Input
+                  type="checkbox"
+                  id="email-settings"
+                  checked={hasEmailsEnabled}
+                  disabled={isSubmitting}
+                  onChange={this.handleEmailSettingsChange}
+                />
+                <label className="form-check-label ml-2" htmlFor="email-settings">
+                  Receive course emails such as reminders, schedule updates, and
+                  other critical announcements.
+                </label>
+              </div>
+            </>
+          }
+          onClose={this.handleOnClose}
+          buttons={[
+            {
+              label: (
+                <>
+                  {isSubmitting &&
+                    <FontAwesomeIcon className="mr-2" icon={['fas', 'spinner']} spin />
+                  }
+                  {isSubmitting ? 'Saving' : 'Save'}
+                  {' changes'}
+                  {isSubmitting && '...'}
+                </>
+              ),
+              buttonType: 'primary',
+              disabled: isSubmitting || !isFormChanged,
+              onClick: this.handleSaveButtonClick,
+            },
+          ]}
+          open
+        />
+      </>
+    );
+  }
+}
 
 EmailSettingsModal.propTypes = {
   title: PropTypes.string.isRequired,
-  submitting: PropTypes.bool,
+  hasEmailsEnabled: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
-  onEmailSettingsChange: PropTypes.func.isRequired,
 };
 
 

--- a/src/components/CourseCard/EmailSettingsModal.scss
+++ b/src/components/CourseCard/EmailSettingsModal.scss
@@ -1,11 +1,6 @@
 .modal {
-  .modal-content {
-    .modal-footer{
-      .js-close-modal-on-click {
-        margin: auto;
-        width: 100%;
-        border-radius: 0.5rem;
-      }
-    }
+  .modal-title {
+    font-size: 1.5rem;
+    line-height: 1.5;
   }
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -33,11 +33,13 @@ const IndexPage = () => (
                 title="Advanced Analytics Thinking"
                 endDate="2019-11-03"
                 linkToCourse="https://edx.org"
+                hasEmailsEnabled
               />
               <InProgressCourseCard
-                title="Statistics for Analyics"
+                title="Statistics for Analytics"
                 endDate="2019-07-23"
                 linkToCourse="https://edx.org"
+                hasEmailsEnabled={false}
                 microMastersTitle="MicroMasters&reg; Program in Analytics: Essential Tools and Methods"
               />
             </div>
@@ -46,6 +48,7 @@ const IndexPage = () => (
               <UpcomingCourseCard
                 title="Predictive Analytics with Spark"
                 startDate="2019-04-29"
+                hasEmailsEnabled
                 linkToCourse="https://edx.org"
               />
             </div>
@@ -55,6 +58,7 @@ const IndexPage = () => (
                 title="Big Data and How To Use It"
                 endDate="2019-03-08"
                 linkToCourse="https://edx.org"
+                hasEmailsEnabled
                 grade={{ hasPassed: true, numericGrade: 0.97 }}
               />
             </div>


### PR DESCRIPTION
@saleem-latif Figured it'd be easier to create a PR based on your branch for the code review than trying to explain everything in review  comments. This PR address some UX issues as well.

Main updates:
* Passes the `emailSettings` prop to `EmailSettingsModal` so it can show the correct `checked` state on the checkbox.
* Uses the new `Input` component in Paragon (as opposed to `Checkbox`). This avoids the complexity of Paragon's `asInput` component (used under the hood of the `Checkbox` component). This was the agreed direction forward by the Paragon working group for form inputs.
* Uses the `buttons` prop for the `Modal` component to create the "Save changes" button that you see in the UI mocks in Zeplin, instead of using the "Cancel" button as the way to submit the changes.
* Before, the `submitting` prop changed to `true` when the email settings checkbox was changed. A spinner was appearing next to the checkbox label as well. In this PR, the spinner only shows on the "Save changes" button.
* The "Save changes" button is disabled until a change is made to the checkbox that differs from the initial `checked` state.
* Simulates an API request and response (or error).
* On a successful save (promise resolves):
  * Adds a dismissible, success `StatusAlert` in the course card.
  * Updates `hasEmailsEnabled` state so that when you open the modal again, the checkbox shows the correct `checked` state based on the newly updated email settings.
* In the case the API request errors (promise gets rejected), shows an error `StatusAlert` in the modal.