### PR TITLE
Remove grade prop-type

### DIFF
--- a/src/components/CourseCard/CompletedCourseCard.jsx
+++ b/src/components/CourseCard/CompletedCourseCard.jsx
@@ -20,10 +20,6 @@ const CompletedCourseCard = props => (
 
 CompletedCourseCard.propTypes = {
   linkToCourse: PropTypes.string.isRequired,
-  grade: PropTypes.shape({
-    numericGrade: PropTypes.number.isRequired,
-    hasPassed: PropTypes.bool.isRequired,
-  }).isRequired,
 };
 
 export default CompletedCourseCard;


### PR DESCRIPTION
Looks like I missed removing the prop type definition for `grade` in `CompletedCourseCard` now that we're no longer showing final grade.