### PR TITLE
added client only routes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,19 @@
+/**
+ * Implement Gatsby's Node APIs in this file.
+ *
+ * See: https://www.gatsbyjs.org/docs/node-apis/
+ */
+
+exports.onCreatePage = async ({ page, actions }) => {
+  const { createPage } = actions;
+
+  // page.matchPath is a special key that's used for matching pages
+  // only on the client.
+  if (page.path.match(/^\/app/)) {
+    // eslint-disable-next-line no-param-reassign
+    page.matchPath = '/app/*';
+
+    // Update the page.
+    createPage(page);
+  }
+};

--- a/src/pages/app.jsx
+++ b/src/pages/app.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+import { ConnectedRouter } from 'react-router-redux';
+import { PrivateRoute } from '@edx/frontend-auth';
+
+import apiClient from '../data/apiClient';
+import history from '../data/history';
+import Layout from '../components/Layout/Layout';
+import DashboardHome from '../components/DashboardHome/DashboardHome';
+
+// Add icons to font-awesome library
+library.add(fas);
+
+const App = () => (
+  <IntlProvider locale="en">
+    <Layout>
+      <ConnectedRouter history={history}>
+        <React.Fragment>
+          <PrivateRoute
+            path="/app/1"
+            component={DashboardHome}
+            authenticatedAPIClient={apiClient}
+            redirect={process.env.BASE_URL}
+          />
+          <PrivateRoute
+            path="/app/2"
+            component={DashboardHome}
+            authenticatedAPIClient={apiClient}
+            redirect={process.env.BASE_URL}
+          />
+        </React.Fragment>
+      </ConnectedRouter>
+    </Layout>
+  </IntlProvider>
+);
+
+export default App;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -3,11 +3,7 @@ import { IntlProvider } from 'react-intl';
 
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { fas } from '@fortawesome/free-solid-svg-icons';
-import { ConnectedRouter } from 'react-router-redux';
-import { PrivateRoute } from '@edx/frontend-auth';
 
-import apiClient from '../data/apiClient';
-import history from '../data/history';
 import Layout from '../components/Layout/Layout';
 import DashboardHome from '../components/DashboardHome/DashboardHome';
 
@@ -17,16 +13,7 @@ library.add(fas);
 const IndexPage = () => (
   <IntlProvider locale="en">
     <Layout>
-      <ConnectedRouter history={history}>
-        <React.Fragment>
-          <PrivateRoute
-            path="/"
-            component={DashboardHome}
-            authenticatedAPIClient={apiClient}
-            redirect={process.env.BASE_URL}
-          />
-        </React.Fragment>
-      </ConnectedRouter>
+      <DashboardHome />
     </Layout>
   </IntlProvider>
 );


### PR DESCRIPTION
Description: This PR adds routes available only to logged-in users.

JIRA: https://openedx.atlassian.net/browse/ENT-1805

Testing Instructions:

1. Run the application by npm i and then npm start in devstack
2: Browse to http://localhost:8734/ and verify that you see the dashboard home
3: Browse to http://localhost:8734/app/1 and verify that you are redirected to the lms login page
4: Once logged in to lms browse to http://localhost:8734/app/1 and verify that you can see the dashboard 

Server environment pre-requisites: The following variable must be defined in the OS environment:
BASE_URL
LMS_BASE_URL
LOGIN_URL
LOGOUT_URL
CSRF_TOKEN_API_PATH
REFRESH_ACCESS_TOKEN_ENDPOINT
ACCESS_TOKEN_COOKIE_NAME
USER_INFO_COOKIE_NAME

For sample values for the above variable refer to:
https://github.com/edx/edx-portal/blob/2908751ad955bd4902d90a5e7dbccedd100d2300/config/webpack.dev.config.js#L103