### PR TITLE
Update sample links and switch to FontAwesomeIcon

### DIFF
--- a/src/components/CourseCard/BaseCourseCard.jsx
+++ b/src/components/CourseCard/BaseCourseCard.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import moment from 'moment';
+import { faCog, faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { StatusAlert } from '@edx/paragon';
 
@@ -103,7 +104,7 @@ class BaseCourseCard extends Component {
                       alertType="success"
                       dialog={
                         <>
-                          <FontAwesomeIcon className="mr-2" icon={['fas', 'check-circle']} />
+                          <FontAwesomeIcon className="mr-2" icon={faCheckCircle} />
                           Your email settings have been saved.
                         </>
                       }
@@ -134,7 +135,7 @@ class BaseCourseCard extends Component {
                       });
                     }}
                   >
-                    <FontAwesomeIcon className="mr-2" icon={['fas', 'cog']} />
+                    <FontAwesomeIcon className="mr-2" icon={faCog} />
                     Email settings
                   </button>
                   {modals.emailSettings &&

--- a/src/components/CourseCard/CompletedCourseCard.jsx
+++ b/src/components/CourseCard/CompletedCourseCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { faDownload } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import BaseCourseCard from './BaseCourseCard';
@@ -9,7 +10,7 @@ const CompletedCourseCard = props => (
     <div className="completed row no-gutters">
       <div className="col-12">
         <a className="btn btn-primary btn-xs-block mr-2 mb-2 mb-sm-0" href="/">
-          <FontAwesomeIcon className="mr-2" icon={['fas', 'download']} />
+          <FontAwesomeIcon className="mr-2" icon={faDownload} />
           Download Certificate
         </a>
         <a className="btn btn-outline-primary btn-xs-block" href="/">View Course</a>

--- a/src/components/CourseCard/EmailSettingsModal.jsx
+++ b/src/components/CourseCard/EmailSettingsModal.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Input, Modal, StatusAlert } from '@edx/paragon';
+import { faExclamationTriangle, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import './EmailSettingsModal.scss';
@@ -78,7 +79,7 @@ class EmailSettingsModal extends Component {
                   dialog={
                     <div className="d-flex">
                       <div>
-                        <FontAwesomeIcon className="mr-3" icon={['fas', 'exclamation-triangle']} />
+                        <FontAwesomeIcon className="mr-3" icon={faExclamationTriangle} />
                       </div>
                       <div>
                         An error occurred while saving your email settings. Please try again.
@@ -110,7 +111,7 @@ class EmailSettingsModal extends Component {
               label: (
                 <>
                   {isSubmitting &&
-                    <FontAwesomeIcon className="mr-2" icon={['fas', 'spinner']} spin />
+                    <FontAwesomeIcon className="mr-2" icon={faSpinner} spin />
                   }
                   {isSubmitting ? 'Saving' : 'Save'}
                   {' changes'}

--- a/src/components/DashboardHome/__snapshots__/Sidebar.test.jsx.snap
+++ b/src/components/DashboardHome/__snapshots__/Sidebar.test.jsx.snap
@@ -14,13 +14,25 @@ exports[`<Sidebar /> renders correctly 1`] = `
       className="list-unstyled"
     >
       <li>
-        <span
-          aria-hidden={true}
-          className="fa fa-file mr-2 text-primary"
-          id="Icon1"
-        />
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-file fa-w-12 mr-2 text-primary"
+          data-icon="file"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 384 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
         <a
-          href="https://edx.org"
+          href="https://edx.org/degree-requirements"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -28,13 +40,25 @@ exports[`<Sidebar /> renders correctly 1`] = `
         </a>
       </li>
       <li>
-        <span
-          aria-hidden={true}
-          className="fa fa-file mr-2 text-primary"
-          id="Icon1"
-        />
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-file fa-w-12 mr-2 text-primary"
+          data-icon="file"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 384 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
         <a
-          href="https://edx.org"
+          href="https://edx.org/student-record"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/src/components/DashboardHome/sampleLinks.js
+++ b/src/components/DashboardHome/sampleLinks.js
@@ -10,11 +10,11 @@ const linksData = {
   links: [
     {
       title: 'Degree Requirements',
-      href: 'https://edx.org',
+      href: 'https://edx.org/degree-requirements',
     },
     {
       title: 'Student Record',
-      href: 'https://edx.org',
+      href: 'https://edx.org/student-record',
     },
   ],
 };

--- a/src/components/Links/Links.jsx
+++ b/src/components/Links/Links.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Icon } from '@edx/paragon';
+import { faFile } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 function Links(props) {
   const { title, links, className } = props;
 
   const linkItems = links.map(link => (
     <li key={link.href}>
-      <Icon className={['fa', 'fa-file', 'mr-2', 'text-primary']} />
+      <FontAwesomeIcon className="mr-2 text-primary" icon={faFile} />
       <a href={link.href} target="_blank" rel="noopener noreferrer">{link.title}</a>
     </li>
   ));

--- a/src/components/Links/__snapshots__/Links.test.jsx.snap
+++ b/src/components/Links/__snapshots__/Links.test.jsx.snap
@@ -14,11 +14,23 @@ exports[`<Links /> renders correctly 1`] = `
       className="list-unstyled"
     >
       <li>
-        <span
-          aria-hidden={true}
-          className="fa fa-file mr-2 text-primary"
-          id="Icon1"
-        />
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-file fa-w-12 mr-2 text-primary"
+          data-icon="file"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 384 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
         <a
           href="https://example1.com"
           rel="noopener noreferrer"
@@ -28,11 +40,23 @@ exports[`<Links /> renders correctly 1`] = `
         </a>
       </li>
       <li>
-        <span
-          aria-hidden={true}
-          className="fa fa-file mr-2 text-primary"
-          id="Icon1"
-        />
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-file fa-w-12 mr-2 text-primary"
+          data-icon="file"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 384 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
         <a
           href="https://example2.com"
           rel="noopener noreferrer"
@@ -42,11 +66,23 @@ exports[`<Links /> renders correctly 1`] = `
         </a>
       </li>
       <li>
-        <span
-          aria-hidden={true}
-          className="fa fa-file mr-2 text-primary"
-          id="Icon1"
-        />
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-file fa-w-12 mr-2 text-primary"
+          data-icon="file"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 384 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M224 136V0H24C10.7 0 0 10.7 0 24v464c0 13.3 10.7 24 24 24h336c13.3 0 24-10.7 24-24V160H248c-13.2 0-24-10.8-24-24zm160-14.1v6.1H256V0h6.1c6.4 0 12.5 2.5 17 7l97.9 98c4.5 4.5 7 10.6 7 16.9z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
         <a
           href="https://example3.com"
           rel="noopener noreferrer"

--- a/src/pages/app.jsx
+++ b/src/pages/app.jsx
@@ -1,24 +1,19 @@
 import React from 'react';
 import { IntlProvider } from 'react-intl';
-
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { fas } from '@fortawesome/free-solid-svg-icons';
 import { ConnectedRouter } from 'react-router-redux';
 import { PrivateRoute } from '@edx/frontend-auth';
 
-import apiClient from '../data/apiClient';
-import history from '../data/history';
 import Layout from '../components/Layout/Layout';
 import DashboardHome from '../components/DashboardHome/DashboardHome';
 
-// Add icons to font-awesome library
-library.add(fas);
+import apiClient from '../data/apiClient';
+import history from '../data/history';
 
 const App = () => (
   <IntlProvider locale="en">
     <Layout>
       <ConnectedRouter history={history}>
-        <React.Fragment>
+        <>
           <PrivateRoute
             path="/app/1"
             component={DashboardHome}
@@ -31,7 +26,7 @@ const App = () => (
             authenticatedAPIClient={apiClient}
             redirect={process.env.BASE_URL}
           />
-        </React.Fragment>
+        </>
       </ConnectedRouter>
     </Layout>
   </IntlProvider>


### PR DESCRIPTION
I noticed that since we're using the `href` from `sampleLinks.js` as the `key` for each list item in the `Links` component, we were getting warnings about duplicate keys since the sample links were configured to have the same `href`. I updated the sample hrefs such that they are unique.

Another change in this PR was to switch from using Paragon's `Icon` component in our `Links` component to `FontAwesomeIcon` so we're using SVG icons everywhere.

When doing this, the tests ended up failing because the icons were being added to the font-awesome "library" in `App.jsx`. When testing components in isolation (i.e., outside of the `App.jsx` context), the required icons are not present in the font-awesome library. To fix this, I refactored our use of `FontAwesomeIcon` throughout the app where we pull in the specific SVG icons we need from font-awesome directly in the component itself (as opposed to adding icons to the "library" in `App.jsx`).