### PR TITLE
Add ADR for multideployment strategy

### DIFF
--- a/docs/decisions/0001-record-architecture-decisions.rst
+++ b/docs/decisions/0001-record-architecture-decisions.rst
@@ -1,0 +1,32 @@
+1. Record Architecture Decisions
+--------------------------------
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+We would like to keep a historical record on the architectural
+decisions we make with this app as it evolves over time.
+
+Decision
+--------
+
+We will use Architecture Decision Records, as described by
+Michael Nygard in `Documenting Architecture Decisions`_
+
+.. _Documenting Architecture Decisions: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+Consequences
+------------
+
+See Michael Nygard's article, linked above.
+
+References
+----------
+
+* https://resources.sei.cmu.edu/asset_files/Presentation/2017_017_001_497746.pdf
+* https://github.com/npryce/adr-tools/tree/master/doc/adr

--- a/docs/decisions/0002-multi-deployment-strategy.rst
+++ b/docs/decisions/0002-multi-deployment-strategy.rst
@@ -1,0 +1,47 @@
+2. Multi deployment strategy
+============================
+
+Status
+------
+
+Draft
+
+Context
+-------
+
+We would like to be able to theme and add custom pages to the learner portal
+at build time so that we may build and deploy multiple versions of this app
+for different customers.
+
+Decision
+--------
+
+We will store the configuration (theming and pages) that will be baked into
+this app in a separate service. At build time, we will call this services API,
+collect the configuration, and dynamically build the pages and set the theme.
+
+At this time we will store the configuration in the portal-designer application
+(https://github.com/edx/portal-designer). Since we are using a plugin to
+collect the data and it stores that data into an abstracted layer (GraphQL),
+we will be able to swap out this source (or add to it) in the future if we
+want.
+
+This application will accept a environment variable called SITENAME which will
+is the key by which all configuration data will be stored. Calling the app
+with a SITENAME will tell the build server to gather the configuration for that
+key and then build using that configuration.
+
+In keeping with our web development norms, the built application will be
+exported to `dist` (instead of the Gatsby-specific `public` so that it may be
+deployed list the rest of our apps.
+
+This app will not be responsible for building multiple versions of itself. When
+`npm run build` is ran, only a single deployment from a single configuration
+will be built.
+
+Consequences
+------------
+
+Since the responsibility for building multiple deployments of this app will not
+be handled by itself, that responsibility is now pushed to the deployment
+pipeline.

--- a/docs/decisions/0002-multi-deployment-strategy.rst
+++ b/docs/decisions/0002-multi-deployment-strategy.rst
@@ -22,18 +22,18 @@ collect the configuration, and dynamically build the pages and set the theme.
 
 At this time we will store the configuration in the portal-designer application
 (https://github.com/edx/portal-designer). Since we are using a plugin to
-collect the data and it stores that data into an abstracted layer (GraphQL),
+collect the data and store it into an abstracted layer (GraphQL),
 we will be able to swap out this source (or add to it) in the future if we
 want.
 
-This application will accept a environment variable called SITENAME which will
+This application will accept an environment variable called SITENAME which will
 is the key by which all configuration data will be stored. Calling the app
 with a SITENAME will tell the build server to gather the configuration for that
 key and then build using that configuration.
 
 In keeping with our web development norms, the built application will be
 exported to `dist` (instead of the Gatsby-specific `public` so that it may be
-deployed list the rest of our apps.
+deployed like the rest of our apps.
 
 This app will not be responsible for building multiple versions of itself. When
 `npm run build` is ran, only a single deployment from a single configuration


### PR DESCRIPTION
This is different than the initial design I had proposed. I think this is cleaner than having to built multi-deployment work into every app we want it in. It will now exist in the pipeline code. 