### PR TITLE
Add multiple environments for build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_script:
 script:
   - npm run lint
   - npm run test
-  - npm run build
+  - ACTIVE_ENV=development npm run build

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,12 @@
+// used for multiple environments. This allows us to use `gatsby build` with
+// different configurations instead of just 'production'
+// eg.
+// $ ACTIVE_ENV=<env_name> npm run build
+const activeEnv =
+  process.env.ACTIVE_ENV || process.env.NODE_ENV || 'development';
+
 require('dotenv').config({
-  path: `.env.${process.env.NODE_ENV}`,
+  path: `.env.${activeEnv}`,
 });
 
 let pagesApiUrl;


### PR DESCRIPTION
This allows us to use `gatsby build` with different configurations instead of just ‘production’
eg.
```
$ ACTIVE_ENV=<env_name> npm run build
```
This also sets it so travis will use `development` for build checks when making pull requests.