### PR TITLE
updating gatsby-node on how page path is matched. adding some other docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ The project itself will run on  ```http://localhost:8734```
 
 you can test your graphql queries with the playground, found here:  ```http://localhost:8734/___graphql```
 
+## How to run/serve a production build locally
+
+```
+npm run build   # Builds to dist folder
+rm -rf public   # If you already have a public folder there
+mv dist public  # Rename dist folder
+npm run serve   # Run server. This command will automatically look at public/ directory
+```
 
 ## Testing
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,7 +9,7 @@ exports.onCreatePage = async ({ page, actions }) => {
 
   // page.matchPath is a special key that's used for matching pages
   // only on the client.
-  if (page.path.match(/^\/app/)) {
+  if (page.path.match(/^\/app\//)) {
     // eslint-disable-next-line no-param-reassign
     page.matchPath = '/app/*';
 


### PR DESCRIPTION
An attempt to fix auth redirect not occurring on stage and production

Running theory:

Without the trailing slash in that match, we were allowing a path starting with `/app` to be matched regardless of what followed. The side effect of this was being able to hit a path starting in `/app` but never actually hit a `<PrivateRoute` and therefore never being redirected