### PR TITLE
Upgrade @edx/edx-bootstrap, fix course card responsiveness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -889,9 +889,9 @@
       }
     },
     "@edx/edx-bootstrap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/edx-bootstrap/-/edx-bootstrap-2.1.0.tgz",
-      "integrity": "sha512-9/CkIP1IsldKvOAS/T2OYeBnyuNWwX+u5GVR1kxw1YUCQbFw0W2M/Nz0HbIhG82H4O64uQqfdxnd1QpRJn07LA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@edx/edx-bootstrap/-/edx-bootstrap-2.2.1.tgz",
+      "integrity": "sha512-HkQ45u46ejX7WYwJX6ar/0FGBjx4F7bZvt3Dd4A677st0ic/47X5vQlqMqmK/M08C+GXaunNbZdbyF/ROrmwxw==",
       "requires": {
         "bootstrap": "^4.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "",
   "dependencies": {
-    "@edx/edx-bootstrap": "^2.1.0",
+    "@edx/edx-bootstrap": "^2.2.1",
     "@edx/frontend-auth": "^5.1.3",
     "@edx/frontend-component-footer": "^3.0.4",
     "@edx/frontend-component-site-header": "^2.1.6",

--- a/src/components/CourseCard/BaseCourseCard.jsx
+++ b/src/components/CourseCard/BaseCourseCard.jsx
@@ -68,7 +68,7 @@ class BaseCourseCard extends Component {
       <div className={classNames('card mb-4', { 'is-micromasters': !!microMastersTitle })}>
         <div className="card-body">
           <div className="row no-gutters mb-3">
-            <div className="col-xs-12 col-md-8">
+            <div className="col-lg-12 col-xl-8">
               {microMastersTitle && (
                 <p className="font-weight-bold w-75 mb-2">
                   {microMastersTitle}
@@ -89,7 +89,7 @@ class BaseCourseCard extends Component {
               )}
             </div>
             {buttons && (
-              <div className="col-xs-12 col-md-4 text-md-right mt-3 mt-md-0">
+              <div className="col-lg-12 col-xl-4 text-xl-right mt-3 mt-xl-0">
                 {buttons}
               </div>
             )}

--- a/src/components/DashboardHome/Sidebar.jsx
+++ b/src/components/DashboardHome/Sidebar.jsx
@@ -8,10 +8,10 @@ import SidebarBlock from './SidebarBlock';
 
 const Sidebar = () => (
   <>
-    <SidebarBlock title="Program Documents" className="mb-4">
+    <SidebarBlock title="Program Documents" className="mb-5">
       <Links id={linksData.id} links={linksData.links} />
     </SidebarBlock>
-    <SidebarBlock title="Manage Your Degree" className="mb-4">
+    <SidebarBlock title="Manage Your Degree" className="mb-5">
       <p>Go to Georgia Tech portal to</p>
       <ul>
         <li>Add or drop courses</li>
@@ -24,7 +24,7 @@ const Sidebar = () => (
       <p>
         <a href="https://www.edx.org/" target="_blank" rel="noopener noreferrer">
           Go to Georgia Tech portal
-          <FontAwesomeIcon className="ml-2 text-primary" icon={faExternalLinkAlt} />
+          <FontAwesomeIcon className="ml-2 text-primary" icon={faExternalLinkAlt} size="sm" />
         </a>
       </p>
     </SidebarBlock>
@@ -32,7 +32,7 @@ const Sidebar = () => (
       <p>
         <a href="https://www.edx.org/" target="_blank" rel="noopener noreferrer">
           Go to edX help center
-          <FontAwesomeIcon className="ml-2 text-primary" icon={faExternalLinkAlt} />
+          <FontAwesomeIcon className="ml-2 text-primary" icon={faExternalLinkAlt} size="sm" />
         </a>
       </p>
     </SidebarBlock>

--- a/src/components/DashboardHome/__snapshots__/Sidebar.test.jsx.snap
+++ b/src/components/DashboardHome/__snapshots__/Sidebar.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`<Sidebar /> renders correctly 1`] = `
 Array [
   <section
-    className="mb-4"
+    className="mb-5"
   >
     <h2
       className="mb-2"
@@ -189,7 +189,7 @@ Array [
     </button>
   </section>,
   <section
-    className="mb-4"
+    className="mb-5"
   >
     <h2
       className="mb-2"
@@ -228,7 +228,7 @@ Array [
         Go to Georgia Tech portal
         <svg
           aria-hidden="true"
-          className="svg-inline--fa fa-external-link-alt fa-w-18 ml-2 text-primary"
+          className="svg-inline--fa fa-external-link-alt fa-w-18 fa-sm ml-2 text-primary"
           data-icon="external-link-alt"
           data-prefix="fas"
           focusable="false"
@@ -261,7 +261,7 @@ Array [
         Go to edX help center
         <svg
           aria-hidden="true"
-          className="svg-inline--fa fa-external-link-alt fa-w-18 ml-2 text-primary"
+          className="svg-inline--fa fa-external-link-alt fa-w-18 fa-sm ml-2 text-primary"
           data-icon="external-link-alt"
           data-prefix="fas"
           focusable="false"


### PR DESCRIPTION
To bring in the responsive typography that was released in the latest version of `@edx/edx-boostrap`, this PR upgrades that package. Also, at certain screen sizes, the buttons in the course cards were wrapping the text onto 2 lines. I've updated the responsive columns in the course card to prevent the wrapping from happening.