### PR TITLE
fix due date filter and misc updates

### DIFF
--- a/src/components/CourseCard/InProgressCourseCard.jsx
+++ b/src/components/CourseCard/InProgressCourseCard.jsx
@@ -11,7 +11,8 @@ const InProgressCourseCard = (props) => {
   );
 
   const filteredNotifications = props.notifications.filter((notification) => {
-    if (moment(notification.date).diff(moment(), 'days') <= 7) {
+    const now = moment();
+    if (moment(notification.date).isBetween(now, moment(now).add('1', 'w'))) {
       return notification;
     }
     return false;

--- a/src/components/CourseCard/Notification.jsx
+++ b/src/components/CourseCard/Notification.jsx
@@ -17,10 +17,9 @@ const Notification = props => (
           */}
           <div className="col-12">
             <a href={props.url}>{props.name}</a>
-            {' is due in '}
+            {' is due '}
             <span className="font-weight-bold">
-              {moment(props.date).diff(moment(), 'days')}
-              {' days'}
+              {moment(props.date).fromNow()}
             </span>
             {' on '}
             {moment(props.date).format('ddd MMMM D, YYYY')}

--- a/src/components/DashboardHome/DashboardHome.jsx
+++ b/src/components/DashboardHome/DashboardHome.jsx
@@ -26,9 +26,9 @@ const DashboardHome = () => (
         </div>
         <MediaQuery minWidth={breakpoints.large.minWidth}>
           {matches => matches && (
-            <div className="col offset-lg-1">
+            <aside className="col offset-lg-1">
               <Sidebar />
-            </div>
+            </aside>
           )}
         </MediaQuery>
       </div>

--- a/src/components/DashboardHome/SidebarBlock.jsx
+++ b/src/components/DashboardHome/SidebarBlock.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SidebarBlock = props => (
-  <section className={props.className}>
+  <div className={props.className}>
     <h2 className="mb-2">{props.title}</h2>
     {props.children}
-  </section>
+  </div>
 );
 
 SidebarBlock.propTypes = {

--- a/src/components/DashboardHome/sampleApiResponse.js
+++ b/src/components/DashboardHome/sampleApiResponse.js
@@ -19,7 +19,7 @@ const sampleApiResponse = {
       due_dates: [{
         name: 'Assignment 1',
         url: 'https://edx.org',
-        date: '2019-06-05T07:50:00Z',
+        date: '2019-06-10T07:50:00Z',
       }, {
         name: 'Assignment 2',
         url: 'https://edx.org',

--- a/src/components/DashboardHome/tests/__snapshots__/Sidebar.test.jsx.snap
+++ b/src/components/DashboardHome/tests/__snapshots__/Sidebar.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Sidebar /> renders correctly 1`] = `
 Array [
-  <section
+  <div
     className="mb-5"
   >
     <h2
@@ -187,8 +187,8 @@ Array [
         show all 8
       </span>
     </button>
-  </section>,
-  <section
+  </div>,
+  <div
     className="mb-5"
   >
     <h2
@@ -245,8 +245,8 @@ Array [
         </svg>
       </a>
     </p>
-  </section>,
-  <section>
+  </div>,
+  <div>
     <h2
       className="mb-2"
     >
@@ -278,6 +278,6 @@ Array [
         </svg>
       </a>
     </p>
-  </section>,
+  </div>,
 ]
 `;


### PR DESCRIPTION
Realized that the due date filter to only select the due dates in the next week was not handling past dates well, resulting in a negative number appearing in the due dates (e.g., "due in -4 days"). This PR primarily addresses this issue such that only dates between now and 1 week from now are shown using some of moment.js's utility functions.