### PR TITLE
Use props instead of query in Layout

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,9 +4,6 @@ require('dotenv').config({
 
 module.exports = {
   siteMetadata: {
-    logo: 'https://www.edx.org/sites/default/files/open-edx-logo-with-reg.png',
-    siteName: 'Open Edx',
-    siteUrl: 'https://www.edx.org/',
     programUUID: 'aa7316ce-1b06-4d4a-b612-7a9c652f2990',
     providerSlug: 'saml-edx-saml-test',
   },

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { StaticQuery, graphql } from 'gatsby';
 import PropTypes from 'prop-types';
 import SiteHeader from '@edx/frontend-component-site-header';
 import SiteFooter from '@edx/frontend-component-footer';
@@ -8,104 +7,93 @@ import { connect } from 'react-redux';
 
 import './Layout.scss';
 
-const LayoutQuery = graphql`
-  query {
-    site {
-      siteMetadata {
-        logo
-        siteName
-        siteUrl
-      }
-    }
-  }
-`;
-
-const Layout = ({ children, username, avatar }) => (
-  <StaticQuery
-    query={LayoutQuery}
-    render={data => (
-      <>
-        <Helmet titleTemplate="%s - edX" defaultTitle="edX" />
-        <SiteHeader
-          logo={data.site.siteMetadata.logo}
-          logoDestination={data.site.siteMetadata.siteUrl}
-          logoAltText={data.site.siteMetadata.siteName}
-          loggedIn={!!username}
-          username={username}
-          avatar={avatar}
-          userMenu={[
-            {
-              type: 'item',
-              href: process.env.LMS_BASE_URL,
-              content: 'Dashboard',
-            },
-            {
-              type: 'item',
-              href: '/',
-              content: 'My Masters Degree',
-            },
-            {
-              type: 'item',
-              href: `${process.env.LMS_BASE_URL}/u/${username}`,
-              content: 'Profile',
-            },
-            {
-              type: 'item',
-              href: `${process.env.LMS_BASE_URL}/account/settings`,
-              content: 'Account Settings',
-            },
-            {
-              type: 'item',
-              href: process.env.LOGOUT_URL,
-              content: 'Sign out',
-            },
-          ]}
-          loggedOutItems={[
-            { type: 'item', href: '#', content: 'Login' },
-            { type: 'item', href: '#', content: 'Sign Up' },
-          ]}
-          skipNavId="content"
-        />
-        <>{children}</>
-        <SiteFooter
-          siteName={data.site.siteMetadata.siteName}
-          siteLogo={data.site.siteMetadata.logo}
-          marketingSiteBaseUrl="https://www.example.com"
-          supportUrl="https://www.example.com/support"
-          contactUrl="https://www.example.com/contact"
-          openSourceUrl="https://www.example.com/open"
-          termsOfServiceUrl="https://www.example.com/terms-of-service"
-          privacyPolicyUrl="https://www.example.com/privacy-policy"
-          facebookUrl="https://www.facebook.com"
-          twitterUrl="https://www.twitter.com"
-          youTubeUrl="https://www.youtube.com"
-          linkedInUrl="https://www.linkedin.com"
-          googlePlusUrl="https://plus.google.com"
-          redditUrl="https://reddit.com"
-          appleAppStoreUrl="https://store.apple.com"
-          googlePlayUrl="https://play.google.com"
-          handleAllTrackEvents={() => {}}
-        />
-      </>
-    )}
-  />
+const Layout = props => (
+  <>
+    <Helmet titleTemplate="%s - edX" defaultTitle="edX" />
+    <SiteHeader
+      logo={props.logo}
+      logoDestination={props.siteUrl}
+      logoAltText={props.siteName}
+      loggedIn={!!props.username}
+      username={props.username}
+      avatar={props.avatar}
+      userMenu={[
+        {
+          type: 'item',
+          href: process.env.LMS_BASE_URL,
+          content: 'Dashboard',
+        },
+        {
+          type: 'item',
+          href: '/',
+          content: 'My Masters Degree',
+        },
+        {
+          type: 'item',
+          href: `${process.env.LMS_BASE_URL}/u/${props.username}`,
+          content: 'Profile',
+        },
+        {
+          type: 'item',
+          href: `${process.env.LMS_BASE_URL}/account/settings`,
+          content: 'Account Settings',
+        },
+        {
+          type: 'item',
+          href: process.env.LOGOUT_URL,
+          content: 'Sign out',
+        },
+      ]}
+      loggedOutItems={[
+        { type: 'item', href: '#', content: 'Login' },
+        { type: 'item', href: '#', content: 'Sign Up' },
+      ]}
+      skipNavId="content"
+    />
+    <>{props.children}</>
+    <SiteFooter
+      siteName={props.siteName}
+      siteLogo={props.logo}
+      marketingSiteBaseUrl="https://www.example.com"
+      supportUrl="https://www.example.com/support"
+      contactUrl="https://www.example.com/contact"
+      openSourceUrl="https://www.example.com/open"
+      termsOfServiceUrl="https://www.example.com/terms-of-service"
+      privacyPolicyUrl="https://www.example.com/privacy-policy"
+      facebookUrl="https://www.facebook.com"
+      twitterUrl="https://www.twitter.com"
+      youTubeUrl="https://www.youtube.com"
+      linkedInUrl="https://www.linkedin.com"
+      googlePlusUrl="https://plus.google.com"
+      redditUrl="https://reddit.com"
+      appleAppStoreUrl="https://store.apple.com"
+      googlePlayUrl="https://play.google.com"
+      handleAllTrackEvents={() => {}}
+    />
+  </>
 );
 
 Layout.defaultProps = {
-  children: [],
-  username: null,
   avatar: null,
+  children: [],
+  logo: 'https://www.edx.org/sites/default/files/open-edx-logo-with-reg.png',
+  siteName: 'Open Edx',
+  siteUrl: 'https://open.edx.org/',
+  username: null,
 };
 
 Layout.propTypes = {
-  children: PropTypes.node,
-  username: PropTypes.string,
   avatar: PropTypes.string,
+  children: PropTypes.node,
+  logo: PropTypes.string,
+  siteName: PropTypes.string,
+  siteUrl: PropTypes.string,
+  username: PropTypes.string,
 };
 
 const ConnectedLayout = connect(state => ({
-  username: state.authentication.username,
   avatar: state.userAccount.profileImage.imageUrlMedium,
+  username: state.authentication.username,
 }))(Layout);
 
 export default ConnectedLayout;


### PR DESCRIPTION
Pages now hold their own branding config, so we don't need to do a query in the Layout.

I moved the siteMetadata fake values into the default props for now since we don't have the plugin  and APIs ready yet. These should be set to null once those are merged. 