### PR TITLE
Add dummy branding data to portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Testing is supported with Jest and Enzyme. To run tests, use:
 
 ```$ npm test```
 
+to use dummy branding data, add `useDummyData` to the `options` object of the `gatsby-source-wagtail` plugin
+
+```
+{
+  resolve: 'gatsby-source-wagtail',
+    options: {
+      useDummyData: true,
+    }
+}
+```
+
 ## Other useful commands
 
 ```$ npm clean```

--- a/plugins/gatsby-source-wagtail/gatsby-node.js
+++ b/plugins/gatsby-source-wagtail/gatsby-node.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch');
+const dummyData = require('./test/dummy.json');
 
 exports.sourceNodes = async (
   { actions, createNodeId, createContentDigest },
@@ -8,6 +9,12 @@ exports.sourceNodes = async (
   // Gatsby adds a configOption that's not needed for this plugin, delete it
   delete configOptions.plugins; // eslint-disable-line
   const fetchBrandingData = async () => {
+    // switch to load dummy data from the cms for testing purposes.
+    // set "useDummyData" to true in this plugins options in the gatsby-config
+    // dummy data lives at './test/dummy.json'
+    if (configOptions.useDummyData) {
+      return dummyData;
+    }
     try {
       const response = await fetch(configOptions.pagesApiUrl);
       return await response.json();

--- a/plugins/gatsby-source-wagtail/test/dummy.json
+++ b/plugins/gatsby-source-wagtail/test/dummy.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": 1,
+    "title": "Root",
+    "slug": "root",
+    "last_published_at": null,
+    "type": "wagtailcore.Page"
+  },
+  {
+    "id": 2,
+    "title": "Welcome to your new Wagtail site!",
+    "slug": "home",
+    "last_published_at": null,
+    "type": "wagtailcore.Page"
+  },
+  {
+    "id": 3,
+    "title": "Hogwarts School of Witchcraft and Wizardry",
+    "slug": "hogwarts-school-witchcraft-and-wizardry",
+    "last_published_at": "2019-06-25T15:00:17.641821Z",
+    "branding": [
+      {
+        "banner_border_color": "#f08080",
+        "cover_image": "",
+        "texture_image": "",
+        "organization_logo": {
+          "url": "",
+          "alt": "test-img-alt-text"
+        }
+      }
+    ],
+    "type": "pages.IndexPage"
+  },
+  {
+    "id": 4,
+    "uuid": "3a0857e8-975a-11e9-bc42-526af7764f64",
+    "title": "Potion Making",
+    "slug": "potion-making",
+    "last_published_at": "2019-06-25T15:03:22.507629Z",
+    "branding": [
+      {
+        "banner_border_color": "#f08080",
+        "cover_image": "",
+        "texture_image": "",
+        "organization_logo": {
+          "url": "",
+          "alt": "alt-text"
+        }
+      }
+    ],
+    "type": "pages.ProgramPage"
+  },
+  {
+    "id": 5,
+    "uuid": "75c950d4-975a-11e9-bc42-526af7764f64",
+    "title": "Defense Against the Dark Arts",
+    "slug": "defense-against-dark-arts",
+    "last_published_at": "2019-06-25T15:04:37.004176Z",
+    "branding": [
+      {
+        "banner_border_color": "#f08080",
+        "cover_image": "",
+        "texture_image": "",
+        "organization_logo": {
+          "url": "",
+          "alt": "alt-text"
+        }
+      }
+    ],
+    "type": "pages.ProgramPage"
+  }
+]

--- a/plugins/gatsby-source-wagtail/test/dummy.json
+++ b/plugins/gatsby-source-wagtail/test/dummy.json
@@ -17,6 +17,7 @@
     "id": 3,
     "title": "Hogwarts School of Witchcraft and Wizardry",
     "slug": "hogwarts-school-witchcraft-and-wizardry",
+    "idp_slug": "hogwarts-school-witchcraft-and-wizardry-idp",
     "last_published_at": "2019-06-25T15:00:17.641821Z",
     "branding": [
       {
@@ -36,6 +37,7 @@
     "uuid": "3a0857e8-975a-11e9-bc42-526af7764f64",
     "title": "Potion Making",
     "slug": "potion-making",
+    "idp_slug": "potion-making-idp",
     "last_published_at": "2019-06-25T15:03:22.507629Z",
     "branding": [
       {
@@ -55,6 +57,7 @@
     "uuid": "75c950d4-975a-11e9-bc42-526af7764f64",
     "title": "Defense Against the Dark Arts",
     "slug": "defense-against-dark-arts",
+    "idp_slug": "defense-against-dark-arts-idp",
     "last_published_at": "2019-06-25T15:04:37.004176Z",
     "branding": [
       {


### PR DESCRIPTION
This allows for a more independent deployment of the learn-portal, without the need for a designer backend to provide data. Feel free to edit it in any way or add more too it.