### PR TITLE
Add graphql schema to gatsby

### DIFF
--- a/plugins/gatsby-source-wagtail/gatsby-node.js
+++ b/plugins/gatsby-source-wagtail/gatsby-node.js
@@ -17,7 +17,9 @@ exports.sourceNodes = async (
 
   const fetchBrandingData = async () => {
     // switch to load mock data from the cms for testing purposes.
-    // set "useMockData" to true in this plugins options in the gatsby-config
+    // set "USE_MOCK_DATA" to true in .env.development
+    // remove it or set it to an empty string to remove it. setting it to false does
+    // not remove the mock data!
     // mock data lives at './test/mock.json'
     if (process.env.USE_MOCK_DATA) {
       console.warn('Using fake designer data...');

--- a/plugins/gatsby-source-wagtail/gatsby-node.js
+++ b/plugins/gatsby-source-wagtail/gatsby-node.js
@@ -1,13 +1,20 @@
 const fetch = require('node-fetch');
 const mockData = require('./test/mock.json');
+const typedefs = require('./schema/types.gql');
 
 exports.sourceNodes = async (
   { actions, createNodeId, createContentDigest },
   configOptions,
 ) => {
-  const { createNode } = actions;
+  const { createNode, createTypes } = actions;
   // Gatsby adds a configOption that's not needed for this plugin, delete it
   delete configOptions.plugins; // eslint-disable-line
+
+  // This creates default types for the graphql nodes so that queries do not
+  // break while building pages. If nested types are added to the designer
+  // backend, they will most likely need to be added to the schema.
+  createTypes(typedefs);
+
   const fetchBrandingData = async () => {
     // switch to load mock data from the cms for testing purposes.
     // set "useMockData" to true in this plugins options in the gatsby-config

--- a/plugins/gatsby-source-wagtail/schema/types.gql
+++ b/plugins/gatsby-source-wagtail/schema/types.gql
@@ -16,8 +16,8 @@ module.exports = `
       hostname: String
       idp_slug: String
       type: String
-      branding: [branding]
-      program_documents: [program_documents]
+      branding: branding
+      program_documents: program_documents
   }
   type branding {
     cover_image: String

--- a/plugins/gatsby-source-wagtail/schema/types.gql
+++ b/plugins/gatsby-source-wagtail/schema/types.gql
@@ -1,0 +1,44 @@
+module.exports = `
+  schema {
+    query: Query
+  }
+
+  type Query{
+    page: [page]
+  }
+
+  type page implements Node {
+      id: String
+      uuid: String
+      title: String
+      slug: String
+      last_published_at: Date
+      hostname: String
+      idp_slug: String
+      type: String
+      branding: [branding]
+      program_documents: [program_documents]
+  }
+  type branding {
+    cover_image: String
+    banner_border_color: String
+    texture_image: String
+    organization_logo: organization_logo
+  }
+
+  type organization_logo {
+    url: String
+    alt: String
+  }
+
+  type program_documents {
+    header: String
+    display: Boolean
+    documents: [document]
+  }
+
+  type document {
+    display_text: String
+    document: String
+  }
+`;

--- a/plugins/gatsby-source-wagtail/schema/types.gql
+++ b/plugins/gatsby-source-wagtail/schema/types.gql
@@ -19,6 +19,7 @@ module.exports = `
       branding: branding
       program_documents: program_documents
   }
+  
   type branding {
     cover_image: String
     banner_border_color: String


### PR DESCRIPTION
If we add this graphql schema, we won't have to only rely so much on it's field inference. This way, if a blob coming from the designer api does not have data required by the `createPages` query, that field will be `null` instead of `undefined`, and the build will no longer break.

However, we still have the freedom of adding new data to designer without explicitly adding it to this schema, as gatsby will still infer fields from the data.