### PR TITLE
Fix unbranded landing page check

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,7 +10,8 @@ require('dotenv').config({
 });
 
 let pagesApiUrl;
-if (process.env.UNBRANDED_LANDING_PAGE === true) {
+// All env vars will be passed in as strings
+if (process.env.UNBRANDED_LANDING_PAGE === 'True') {
   pagesApiUrl = `${process.env.DESIGNER_BASE_URL}/api/v1/pages/?type=pages.IndexPage,pages.ProgramPage`;
 } else {
   pagesApiUrl = `${process.env.DESIGNER_BASE_URL}/api/v1/pages/?hostname=${process.env.HOSTNAME}&type=pages.IndexPage,pages.ProgramPage`;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -28,7 +28,7 @@ exports.createPages = async ({ graphql, actions }) => {
   // **Note:** The graphql function call returns a Promise
   // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise for more info
   const { createPage } = actions;
-  const onlyCreateListingPage = process.env.UNBRANDED_LANDING_PAGE;
+  const onlyCreateListingPage = process.env.UNBRANDED_LANDING_PAGE === 'True';
 
   return graphql(`
   {


### PR DESCRIPTION
Environment variables will only ever be strings, so we need to check as
strings and not as booleans.