### PR TITLE
Fix Redirect Loop Between LMS/Learner-Portal

### DIFF
--- a/src/components/common/withAuthentication/tests/withAuthentication.test.jsx
+++ b/src/components/common/withAuthentication/tests/withAuthentication.test.jsx
@@ -24,6 +24,7 @@ apiClient.ensurePublicOrAuthenticationAndCookies = (_, callback) => {
 
 describe('<withAuthentication />', () => {
   it('does not render anything on initial paint', () => {
+    process.env.IDP_SLUG = 'saml-default';
     const MyComponent = () => <div />;
     const AuthenticatedComponent = withAuthentication(MyComponent);
     const wrapper = mount((

--- a/src/components/masters/programs-list/ProgramListPage.jsx
+++ b/src/components/masters/programs-list/ProgramListPage.jsx
@@ -6,7 +6,7 @@ import { StatusAlert } from '@edx/paragon';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { Layout } from '../../common';
+import { Layout, withAuthentication } from '../../common';
 
 import { fetchUserProgramEnrollments } from '../user-program-enrollments';
 
@@ -190,6 +190,9 @@ const mapDispatchToProps = dispatch => ({
   fetchUserProgramEnrollments: () => dispatch(fetchUserProgramEnrollments()),
 });
 
-const ConnectedProgramListPage = connect(mapStateToProps, mapDispatchToProps)(ProgramListPage);
+const ConnectedProgramListPage = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withAuthentication(ProgramListPage));
 
 export default ConnectedProgramListPage;

--- a/src/components/masters/programs-list/tests/ProgramListPage.test.jsx
+++ b/src/components/masters/programs-list/tests/ProgramListPage.test.jsx
@@ -4,11 +4,10 @@ import { shallow } from 'enzyme';
 import { StaticQuery } from 'gatsby';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { StatusAlert } from '@edx/paragon';
 import { Provider } from 'react-redux';
 import { IntlProvider } from 'react-intl';
-import { StatusAlert } from '@edx/paragon';
-
-import ConnectedProgramListPage, { ProgramListPage } from '../ProgramListPage';
+import { ProgramListPage } from '../ProgramListPage';
 
 const mockStore = configureMockStore([thunk]);
 
@@ -54,17 +53,16 @@ describe('ProgramListPage', () => {
           imageUrlMedium: 'someImageData',
         },
       },
-      enrolledPrograms: {
-        loading: true,
-        error: null,
-      },
     });
-
     const tree = renderer
       .create((
         <IntlProvider locale="en">
           <Provider store={store}>
-            <ConnectedProgramListPage pageContext={pageContext} />
+            <ProgramListPage
+              isLoading
+              pageContext={pageContext}
+              fetchUserProgramEnrollments={jest.fn()}
+            />
           </Provider>
         </IntlProvider>
       ))
@@ -82,17 +80,17 @@ describe('ProgramListPage', () => {
           imageUrlMedium: 'someImageData',
         },
       },
-      enrolledPrograms: {
-        loading: false,
-        error: new Error(),
-      },
     });
-
     const tree = renderer
       .create((
         <IntlProvider locale="en">
           <Provider store={store}>
-            <ConnectedProgramListPage pageContext={pageContext} />
+            <ProgramListPage
+              isLoading={false}
+              error={new Error()}
+              pageContext={pageContext}
+              fetchUserProgramEnrollments={jest.fn()}
+            />
           </Provider>
         </IntlProvider>
       ))


### PR DESCRIPTION
The `<ProgramListPage />` was not wrapped with the `<WithAuthentication />` HOC, which caused the redirect to point to the LMS instead of an idp. This fixes that loop, and reworks a few tests.