### PR TITLE
Remove unneeded site metadata

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,9 +18,6 @@ if (process.env.UNBRANDED_LANDING_PAGE === 'True') {
 }
 
 module.exports = {
-  siteMetadata: {
-    programUUID: 'aa7316ce-1b06-4d4a-b612-7a9c652f2990',
-  },
   plugins: [
     {
       resolve: 'gatsby-source-wagtail',


### PR DESCRIPTION
We don't use the site metadata anymore, and the `uuid` for the program is pulled from designer.