### PR TITLE
Rename program homepage to external homepage

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -21,7 +21,7 @@ const transformProgramPageContext = context => (
     programHostname: context.hostname,
     programBranding: context.branding,
     programDocuments: context.program_documents,
-    programHomepage: context.program_homepage,
+    externalProgramWebsite: context.external_program_website,
   }
 );
 
@@ -50,7 +50,7 @@ exports.createPages = async ({ graphql, actions }) => {
             url
           }
         }
-        program_homepage {
+        external_program_website {
           header
           display
           description

--- a/plugins/gatsby-source-wagtail/schema/types.gql
+++ b/plugins/gatsby-source-wagtail/schema/types.gql
@@ -17,7 +17,7 @@ module.exports = `
       type: String
       branding: branding
       program_documents: program_documents
-      program_homepage: program_homepage
+      external_program_website: external_program_website
   }
 
   type branding {
@@ -38,7 +38,7 @@ module.exports = `
     documents: [document]
   }
 
-  type program_homepage {
+  type external_program_website {
     header: String,
     link: link,
     display: Boolean,

--- a/plugins/gatsby-source-wagtail/test/mock.json
+++ b/plugins/gatsby-source-wagtail/test/mock.json
@@ -43,7 +43,7 @@
         }
       ]
     },
-    "program_homepage": {
+    "external_program_website": {
       "header": "edX Portal",
       "link": {
         "display_text": "Click here to go to edX's portal",

--- a/src/components/masters/program/ProgramPage.jsx
+++ b/src/components/masters/program/ProgramPage.jsx
@@ -80,7 +80,7 @@ class ProgramPage extends Component {
       programName,
       programDocuments,
       programBranding,
-      programHomepage,
+      externalProgramWebsite,
     } = pageContext;
 
     return (
@@ -121,7 +121,7 @@ class ProgramPage extends Component {
                             <aside className="col offset-lg-1">
                               <Sidebar
                                 programDocuments={programDocuments}
-                                programHomepage={programHomepage}
+                                externalProgramWebsite={externalProgramWebsite}
                               />
                             </aside>
                           )}
@@ -164,7 +164,7 @@ ProgramPage.propTypes = {
         url: PropTypes.string,
       })),
     }),
-    programHomepage: PropTypes.shape({
+    externalProgramWebsite: PropTypes.shape({
       header: PropTypes.string,
       link: PropTypes.shape({
         display_text: PropTypes.string,

--- a/src/components/masters/program/sidebar/Sidebar.jsx
+++ b/src/components/masters/program/sidebar/Sidebar.jsx
@@ -7,7 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Links from './Links';
 import SidebarBlock from './SidebarBlock';
 
-const Sidebar = ({ programDocuments, programHomepage }) => (
+const Sidebar = ({ programDocuments, externalProgramWebsite }) => (
   <>
     {programDocuments && programDocuments.display &&
       <SidebarBlock title={programDocuments.header} className="mb-5">
@@ -18,20 +18,20 @@ const Sidebar = ({ programDocuments, programHomepage }) => (
         />
       </SidebarBlock>
     }
-    {programHomepage && programHomepage.display &&
-      <SidebarBlock title={programHomepage.header} className="mb-5">
+    {externalProgramWebsite && externalProgramWebsite.display &&
+      <SidebarBlock title={externalProgramWebsite.header} className="mb-5">
         {/* eslint-disable-next-line react/no-danger */}
-        <div dangerouslySetInnerHTML={{ __html: programHomepage.description }} />
+        <div dangerouslySetInnerHTML={{ __html: externalProgramWebsite.description }} />
         <p>
           <a
-            href={programHomepage.link.url}
+            href={externalProgramWebsite.link.url}
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => {
               sendTrackEvent('edx.learner_portal.school_portal_link.clicked');
             }}
           >
-            {programHomepage.link.display_text}
+            {externalProgramWebsite.link.display_text}
             <FontAwesomeIcon
               className="ml-2 text-primary"
               icon={faExternalLinkAlt}
@@ -69,7 +69,7 @@ const Sidebar = ({ programDocuments, programHomepage }) => (
 
 Sidebar.defaultProps = {
   programDocuments: null,
-  programHomepage: null,
+  externalProgramWebsite: null,
 };
 
 Sidebar.propTypes = {
@@ -81,7 +81,7 @@ Sidebar.propTypes = {
       document: PropTypes.string,
     })),
   }),
-  programHomepage: PropTypes.shape({
+  externalProgramWebsite: PropTypes.shape({
     header: PropTypes.string,
     link: PropTypes.shape({
       display_text: PropTypes.string,


### PR DESCRIPTION
I was working off an older version of designer, and did not realize the api had changed.