### PR TITLE
Create EnterprisePage type during build

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -10,10 +10,12 @@ SEGMENT_KEY=''
 DESIGNER_BASE_URL='http://designer.app:18808'
 HOSTNAME='example'
 UNBRANDED_LANDING_PAGE=''
-USE_MOCK_DATA=''
+USE_PROGRAMS_MOCK_DATA=''
+USE_ENTERPRISE_MOCK_DATA=''
 IDP_SLUG='saml-default'
-# uncomment the line below to use mock designer data from plugins/gatsby-source-wagtail/test/mock.json
-# USE_MOCK_DATA=true
+# uncomment ONLY 1 of the lines below to use mock designer data from plugins/gatsby-source-wagtail/test/
+# USE_PROGRAMS_MOCK_DATA=true
+# USE_ENTERPRISE_MOCK_DATA=true
 # uncomment the line below to simulate a deployment in which there is no IDP
 # IDP_SLUG=''
 # uncomment the line below to host the site at /{HOSTNAME}/

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,46 +3,11 @@
  *
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
-const path = require('path');
+const { createPagesWithData } = require('./plugins/gatsby-source-wagtail/createPagesWithData');
 
-const validPageTypes = ['pages.ProgramPage', 'pages.EnterprisePage'];
-const templates = {
-  programListPage: path.resolve('./src/components/masters/programs-list/ProgramListPage.jsx'),
-  programPage: path.resolve('./src/components/masters/program/ProgramPage.jsx'),
-  enterprisePage: path.resolve('./src/components/enterprise/EnterprisePage.jsx'),
-};
-
-
-const transformProgramPageContext = context => (
-  // Transforms GraphQL data into the props expected by the ProgramPage component
-  {
-    pageType: context.type,
-    programSlug: context.slug,
-    programUUID: context.uuid,
-    programName: context.title,
-    programHostname: context.hostname,
-    programBranding: context.branding,
-    programDocuments: context.program_documents,
-    externalProgramWebsite: context.external_program_website,
-  }
-);
-
-const transformEnterprisePageContext = context => (
-  // Transforms GraphQL data into the props expected by the EnterprisePage component
-  {
-    pageType: context.type,
-    enterpriseName: context.title,
-    enterpriseBranding: context.branding,
-  }
-);
-
-exports.createPages = async ({ graphql, actions }) => {
-  // **Note:** The graphql function call returns a Promise
-  // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise for more info
-  const { createPage } = actions;
-  const onlyCreateListingPage = process.env.UNBRANDED_LANDING_PAGE === 'True';
-
-  return graphql(`
+// **Note:** The graphql function call returns a Promise
+// see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise for more info
+exports.createPages = async ({ graphql, actions }) => graphql(`
   {
     allPage {
       nodes {
@@ -83,42 +48,8 @@ exports.createPages = async ({ graphql, actions }) => {
     }
   }  
   `).then((result) => {
-    if (result.data) {
-      const allPagesData = result.data.allPage.nodes
-        .filter(node => validPageTypes.indexOf(node.type) !== -1)
-        .map((node) => {
-          if (node.type === 'pages.ProgramPage') {
-            return transformProgramPageContext(node);
-          } else if (node.type === 'pages.EnterprisePage') {
-            return transformEnterprisePageContext(node);
-          }
-          return node;
-        });
+  if (result.data) {
+    createPagesWithData(result, actions);
+  }
+});
 
-      const hasMultiplePrograms = allPagesData.filter(node => node.type === 'pages.ProgramPage');
-
-      if (hasMultiplePrograms && hasMultiplePrograms.length > 1) {
-        // Create landing page
-        createPage({
-          path: '/',
-          component: templates.programListPage,
-          context: { programs: allPagesData },
-        });
-      }
-
-      if (!onlyCreateListingPage) {
-        // Create Gatsby pages for each page from portal-designer
-        allPagesData.forEach((pageData) => {
-          const isEnterprise = pageData.pageType === 'pages.EnterprisePage';
-          const template = isEnterprise ? templates.enterprisePage : templates.programPage;
-
-          createPage({
-            path: isEnterprise ? '/' : pageData.programSlug,
-            component: template,
-            context: pageData,
-          });
-        });
-      }
-    }
-  });
-};

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * Implement Gatsby's Node APIs in this file.
  *
@@ -47,9 +48,14 @@ exports.createPages = async ({ graphql, actions }) => graphql(`
       }
     }
   }  
-  `).then((result) => {
-  if (result.data) {
-    createPagesWithData(result, actions);
-  }
-});
-
+  `)
+  .then((result) => {
+    if (result && result.data) {
+      createPagesWithData(result, actions);
+    } else {
+      console.error('GraphQL query for fetching page nodes returned no data.');
+    }
+  })
+  .catch((error) => {
+    console.error('An error occurred while fetching page nodes from GraphQL', error);
+  });

--- a/plugins/gatsby-source-wagtail/createPagesWithData.js
+++ b/plugins/gatsby-source-wagtail/createPagesWithData.js
@@ -1,11 +1,6 @@
-const path = require('path');
+const { templates } = require('./templates');
 
 const validPageTypes = ['pages.ProgramPage', 'pages.EnterprisePage'];
-const templates = {
-  programListPage: path.resolve('./src/components/masters/programs-list/ProgramListPage.jsx'),
-  programPage: path.resolve('./src/components/masters/program/ProgramPage.jsx'),
-  enterprisePage: path.resolve('./src/components/enterprise/EnterprisePage.jsx'),
-};
 
 const transformProgramPageContext = context => (
   // Transforms GraphQL data into the props expected by the ProgramPage component
@@ -55,7 +50,7 @@ function createPagesWithData(result, actions) {
     });
   } else {
     // Create landing page if there are multiple programs pages
-    const programs = allPagesData.filter(node => node.type === 'pages.ProgramPage');
+    const programs = allPagesData.filter(node => node.pageType === 'pages.ProgramPage');
     if (programs && programs.length > 1) {
       createPage({
         path: '/',

--- a/plugins/gatsby-source-wagtail/createPagesWithData.js
+++ b/plugins/gatsby-source-wagtail/createPagesWithData.js
@@ -1,0 +1,80 @@
+const path = require('path');
+
+const validPageTypes = ['pages.ProgramPage', 'pages.EnterprisePage'];
+const templates = {
+  programListPage: path.resolve('./src/components/masters/programs-list/ProgramListPage.jsx'),
+  programPage: path.resolve('./src/components/masters/program/ProgramPage.jsx'),
+  enterprisePage: path.resolve('./src/components/enterprise/EnterprisePage.jsx'),
+};
+
+const transformProgramPageContext = context => (
+  // Transforms GraphQL data into the props expected by the ProgramPage component
+  {
+    pageType: context.type,
+    programSlug: context.slug,
+    programUUID: context.uuid,
+    programName: context.title,
+    programHostname: context.hostname,
+    programBranding: context.branding,
+    programDocuments: context.program_documents,
+    externalProgramWebsite: context.external_program_website,
+  }
+);
+
+const transformEnterprisePageContext = context => (
+  // Transforms GraphQL data into the props expected by the EnterprisePage component
+  {
+    pageType: context.type,
+    enterpriseName: context.title,
+    enterpriseBranding: context.branding,
+  }
+);
+
+function createPagesWithData(result, actions) {
+  const { createPage } = actions;
+  const onlyCreateListingPage = process.env.UNBRANDED_LANDING_PAGE === 'True';
+  const allPagesData = result.data.allPage.nodes
+    .filter(node => validPageTypes.indexOf(node.type) !== -1)
+    .map((node) => {
+      if (node.type === 'pages.ProgramPage') {
+        return transformProgramPageContext(node);
+      } else if (node.type === 'pages.EnterprisePage') {
+        return transformEnterprisePageContext(node);
+      }
+      return node;
+    });
+
+  // If we spot an enterprise page, create it, and do not create programs pages
+  const firstPageData = allPagesData && allPagesData[0];
+  const isEnterprise = firstPageData && firstPageData.pageType === 'pages.EnterprisePage';
+  if (isEnterprise) {
+    createPage({
+      path: '/',
+      component: templates.enterprisePage,
+      context: firstPageData,
+    });
+  } else {
+    // Create landing page if there are multiple programs pages
+    const programs = allPagesData.filter(node => node.type === 'pages.ProgramPage');
+    if (programs && programs.length > 1) {
+      createPage({
+        path: '/',
+        component: templates.programListPage,
+        context: { programs },
+      });
+    }
+    // Create Gatsby pages for each page from portal-designer so long as
+    // we are not only building the listings
+    if (!onlyCreateListingPage) {
+      programs.forEach((pageData) => {
+        createPage({
+          path: pageData.programSlug,
+          component: templates.programPage,
+          context: pageData,
+        });
+      });
+    }
+  }
+}
+
+exports.createPagesWithData = createPagesWithData;

--- a/plugins/gatsby-source-wagtail/gatsby-node.js
+++ b/plugins/gatsby-source-wagtail/gatsby-node.js
@@ -1,5 +1,6 @@
 const fetch = require('node-fetch');
-const mockData = require('./test/mock.json');
+const programsMockData = require('./test/mock_programs_pages.json');
+const enterpriseMockData = require('./test/mock_enterprise_page.json');
 const typedefs = require('./schema/types.gql');
 
 exports.sourceNodes = async (
@@ -21,9 +22,13 @@ exports.sourceNodes = async (
     // remove it or set it to an empty string to remove it. setting it to false does
     // not remove the mock data!
     // mock data lives at './test/mock.json'
-    if (process.env.USE_MOCK_DATA) {
-      console.warn('Using fake designer data...');
-      return mockData;
+    if (process.env.USE_ENTERPRISE_MOCK_DATA) {
+      console.warn('Using fake designer enterprise page data...');
+      return enterpriseMockData;
+    }
+    if (process.env.USE_PROGRAMS_MOCK_DATA) {
+      console.warn('Using fake designer programs page data...');
+      return programsMockData;
     }
     try {
       const response = await fetch(configOptions.pagesApiUrl);

--- a/plugins/gatsby-source-wagtail/gatsby-node.js
+++ b/plugins/gatsby-source-wagtail/gatsby-node.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const fetch = require('node-fetch');
 const programsMockData = require('./test/mock_programs_pages.json');
 const enterpriseMockData = require('./test/mock_enterprise_page.json');
@@ -49,6 +51,7 @@ exports.sourceNodes = async (
   });
 
   const data = await fetchBrandingData();
+
   if (data && data.length) {
     data.map(page => processNode(page, 'page'));
   } else {

--- a/plugins/gatsby-source-wagtail/templates.js
+++ b/plugins/gatsby-source-wagtail/templates.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+const templates = {
+  programListPage: path.resolve('./src/components/masters/programs-list/ProgramListPage.jsx'),
+  programPage: path.resolve('./src/components/masters/program/ProgramPage.jsx'),
+  enterprisePage: path.resolve('./src/components/enterprise/EnterprisePage.jsx'),
+};
+
+exports.templates = templates;

--- a/plugins/gatsby-source-wagtail/test/createPagesWithData.test.js
+++ b/plugins/gatsby-source-wagtail/test/createPagesWithData.test.js
@@ -1,0 +1,242 @@
+import { createPagesWithData } from '../createPagesWithData';
+import { templates } from '../templates';
+
+describe('createPagesWithData', () => {
+  it('should only create page based on the type in first node in nodes', () => {
+    const graphqlQueryResult = {
+      data: {
+        allPage: {
+          nodes: [
+            {
+              id: '0de66c11-6c9a-538b-aeb6-767f0013c96d',
+              slug: null,
+              title: 'Example Enterprise',
+              type: 'pages.EnterprisePage',
+              uuid: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+              hostname: null,
+              program_documents: null,
+              external_program_website: null,
+              branding: {},
+            },
+            {
+              id: '0de66c11-6c9a-538b-aeb6-767f0013c96d',
+              slug: null,
+              title: 'Some program we should ignore',
+              type: 'pages.ProgramPage',
+              uuid: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+              hostname: null,
+              program_documents: null,
+              external_program_website: null,
+              branding: {},
+            },
+          ],
+        },
+      },
+    };
+    const actions = { createPage: jest.fn() };
+
+    createPagesWithData(graphqlQueryResult, actions);
+
+    const expectedArgs = {
+      path: '/',
+      component: templates.enterprisePage,
+      context: {
+        pageType: 'pages.EnterprisePage',
+        enterpriseName: 'Example Enterprise',
+        enterpriseBranding: {},
+      },
+    };
+    expect(actions.createPage.mock.calls.length).toEqual(1);
+    expect(actions.createPage).toBeCalledWith({ ...expectedArgs });
+  });
+
+  it('should only create a single programPage if only one programPage is present', () => {
+    const graphqlQueryResult = {
+      data: {
+        allPage: {
+          nodes: [
+            {
+              id: '0de66c11-6c9a-538b-aeb6-767f0013c96d',
+              slug: 'prog-slug',
+              title: 'The best program ever',
+              type: 'pages.ProgramPage',
+              uuid: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+              hostname: null,
+              program_documents: null,
+              external_program_website: null,
+              branding: {},
+            },
+            {
+              id: '0de66c11-6c9a-538b-aeb6-767f0013c96d',
+              slug: null,
+              title: 'Example Enterprise',
+              type: 'pages.EnterprisePage',
+              uuid: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+              hostname: null,
+              program_documents: null,
+              external_program_website: null,
+              branding: {},
+            },
+          ],
+        },
+      },
+    };
+    const actions = { createPage: jest.fn() };
+
+    createPagesWithData(graphqlQueryResult, actions);
+
+    const expectedArgs = {
+      path: 'prog-slug',
+      component: templates.programPage,
+      context: {
+        pageType: 'pages.ProgramPage',
+        programSlug: 'prog-slug',
+        programUUID: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+        programName: 'The best program ever',
+        programHostname: null,
+        programBranding: {},
+        programDocuments: null,
+        externalProgramWebsite: null,
+      },
+    };
+    expect(actions.createPage.mock.calls.length).toEqual(1);
+    expect(actions.createPage).toBeCalledWith({ ...expectedArgs });
+  });
+
+  it('should create list page if multiple programsPage nodes exist.', () => {
+    const graphqlQueryResult = {
+      data: {
+        allPage: {
+          nodes: [
+            {
+              id: '0de66c11-6c9a-538b-aeb6-767f0013c96d',
+              slug: 'prog-slug-1',
+              title: 'Program 1',
+              type: 'pages.ProgramPage',
+              uuid: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+              hostname: null,
+              program_documents: null,
+              external_program_website: null,
+              branding: {},
+            },
+            {
+              id: '0de66c11-6c9a-538b-aeb6-767f0013c96a',
+              slug: 'prog-slug-2',
+              title: 'Program 2',
+              type: 'pages.ProgramPage',
+              uuid: '47fc98b8-9a90-406d-854b-a4e91df0bc8d',
+              hostname: null,
+              program_documents: null,
+              external_program_website: null,
+              branding: {},
+            },
+          ],
+        },
+      },
+    };
+    const actions = { createPage: jest.fn() };
+
+    createPagesWithData(graphqlQueryResult, actions);
+
+    const expectedContext = {
+      programs: [
+        {
+          externalProgramWebsite: null,
+          pageType: 'pages.ProgramPage',
+          programBranding: {},
+          programDocuments: null,
+          programHostname: null,
+          programUUID: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+          programName: 'Program 1',
+          programSlug: 'prog-slug-1',
+        },
+        {
+          externalProgramWebsite: null,
+          pageType: 'pages.ProgramPage',
+          programBranding: {},
+          programDocuments: null,
+          programHostname: null,
+          programUUID: '47fc98b8-9a90-406d-854b-a4e91df0bc8d',
+          programName: 'Program 2',
+          programSlug: 'prog-slug-2',
+        },
+      ],
+    };
+    const expectedArgs = {
+      path: '/',
+      component: templates.programListPage,
+      context: expectedContext,
+    };
+    expect(actions.createPage.mock.calls.length).toEqual(3);
+    expect(actions.createPage).toHaveBeenNthCalledWith(1, { ...expectedArgs });
+  });
+
+  it('should only create list page (and no program pages) if onlyCreateListingPage is true', () => {
+    const graphqlQueryResult = {
+      data: {
+        allPage: {
+          nodes: [
+            {
+              id: '0de66c11-6c9a-538b-aeb6-767f0013c96d',
+              slug: 'prog-slug-1',
+              title: 'Program 1',
+              type: 'pages.ProgramPage',
+              uuid: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+              hostname: null,
+              program_documents: null,
+              external_program_website: null,
+              branding: {},
+            },
+            {
+              id: '0de66c11-6c9a-538b-aeb6-767f0013c96a',
+              slug: 'prog-slug-2',
+              title: 'Program 2',
+              type: 'pages.ProgramPage',
+              uuid: '47fc98b8-9a90-406d-854b-a4e91df0bc8d',
+              hostname: null,
+              program_documents: null,
+              external_program_website: null,
+              branding: {},
+            },
+          ],
+        },
+      },
+    };
+    const actions = { createPage: jest.fn() };
+    process.env.UNBRANDED_LANDING_PAGE = 'True';
+
+    createPagesWithData(graphqlQueryResult, actions);
+
+    const expectedContext = {
+      programs: [
+        {
+          externalProgramWebsite: null,
+          pageType: 'pages.ProgramPage',
+          programBranding: {},
+          programDocuments: null,
+          programHostname: null,
+          programUUID: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+          programName: 'Program 1',
+          programSlug: 'prog-slug-1',
+        },
+        {
+          externalProgramWebsite: null,
+          pageType: 'pages.ProgramPage',
+          programBranding: {},
+          programDocuments: null,
+          programHostname: null,
+          programUUID: '47fc98b8-9a90-406d-854b-a4e91df0bc8d',
+          programName: 'Program 2',
+          programSlug: 'prog-slug-2',
+        },
+      ],
+    };
+    const expectedArgs = {
+      path: '/',
+      component: templates.programListPage,
+      context: expectedContext,
+    };
+    expect(actions.createPage.mock.calls.length).toEqual(1);
+    expect(actions.createPage).toBeCalledWith({ ...expectedArgs });
+  });
+});

--- a/plugins/gatsby-source-wagtail/test/mock.json
+++ b/plugins/gatsby-source-wagtail/test/mock.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 5,
-    "uuid": "d4014686-0fbe-438a-a3b2-425416746e3d",
+    "uuid": "6eefc008-db50-46f0-8746-667f55533a5d",
     "title": "Example site 2",
     "slug": "foo",
     "last_published_at": "2019-07-16T20:58:09.439440Z",
@@ -82,5 +82,24 @@
     },
     "hostname": "example.com",
     "type": "pages.ProgramPage"
+  },
+  {
+    "id": 6,
+    "uuid": "47fc98b8-9a90-406d-854b-a4e91df0bc8c",
+    "title": "Example Enterprise",
+    "slug": null,
+    "last_published_at": "2019-07-16T20:57:48.578177Z",
+    "program_documents": null,
+    "branding": {
+      "texture_image": "http://pigment.github.io/fake-logos/logos/large/color/space-cube.png",
+      "banner_border_color": "#FFFFFF",
+      "cover_image": "http://pigment.github.io/fake-logos/logos/large/color/space-cube.png",
+      "organization_logo": {
+        "alt": "example-enterprise",
+        "url": "http://pigment.github.io/fake-logos/logos/large/color/space-cube.png"
+      }
+    },
+    "hostname": null,
+    "type": "pages.EnterprisePage"
   }
 ]

--- a/plugins/gatsby-source-wagtail/test/mock_enterprise_page.json
+++ b/plugins/gatsby-source-wagtail/test/mock_enterprise_page.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": 6,
+    "uuid": "47fc98b8-9a90-406d-854b-a4e91df0bc8c",
+    "title": "Example Enterprise",
+    "slug": null,
+    "last_published_at": "2019-07-16T20:57:48.578177Z",
+    "program_documents": null,
+    "branding": {
+      "texture_image": "http://pigment.github.io/fake-logos/logos/large/color/space-cube.png",
+      "banner_border_color": "#FFFFFF",
+      "cover_image": "http://pigment.github.io/fake-logos/logos/large/color/space-cube.png",
+      "organization_logo": {
+        "alt": "example-enterprise",
+        "url": "http://pigment.github.io/fake-logos/logos/large/color/space-cube.png"
+      }
+    },
+    "hostname": null,
+    "type": "pages.EnterprisePage"
+  }
+]

--- a/plugins/gatsby-source-wagtail/test/mock_programs_pages.json
+++ b/plugins/gatsby-source-wagtail/test/mock_programs_pages.json
@@ -82,24 +82,5 @@
     },
     "hostname": "example.com",
     "type": "pages.ProgramPage"
-  },
-  {
-    "id": 6,
-    "uuid": "47fc98b8-9a90-406d-854b-a4e91df0bc8c",
-    "title": "Example Enterprise",
-    "slug": null,
-    "last_published_at": "2019-07-16T20:57:48.578177Z",
-    "program_documents": null,
-    "branding": {
-      "texture_image": "http://pigment.github.io/fake-logos/logos/large/color/space-cube.png",
-      "banner_border_color": "#FFFFFF",
-      "cover_image": "http://pigment.github.io/fake-logos/logos/large/color/space-cube.png",
-      "organization_logo": {
-        "alt": "example-enterprise",
-        "url": "http://pigment.github.io/fake-logos/logos/large/color/space-cube.png"
-      }
-    },
-    "hostname": null,
-    "type": "pages.EnterprisePage"
   }
 ]

--- a/plugins/gatsby-source-wagtail/test/mock_programs_pages.json
+++ b/plugins/gatsby-source-wagtail/test/mock_programs_pages.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 5,
-    "uuid": "6eefc008-db50-46f0-8746-667f55533a5d",
+    "uuid": "b3c45a5f-30aa-4423-9e44-11a92ce5d0e7",
     "title": "Example site 2",
     "slug": "foo",
     "last_published_at": "2019-07-16T20:58:09.439440Z",

--- a/src/components/enterprise/EnterprisePage.jsx
+++ b/src/components/enterprise/EnterprisePage.jsx
@@ -11,7 +11,9 @@ const EnterprisePage = () => (
           <div className="col-6">
             <h1>Enterprise Page</h1>
             <p>
-              Note: This page intentionally left blank and will be added to in additional PRs based on this branch. This is due to the refactoring of shared components that will come in a later PR.
+              Note: This page intentionally left blank and will be added to in additional
+              PRs based on this branch. This is due to the refactoring of shared components
+              that will come in a later PR.
             </p>
           </div>
         </div>

--- a/src/components/enterprise/EnterprisePage.jsx
+++ b/src/components/enterprise/EnterprisePage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+
+import { Layout, withAuthentication } from '../common';
+
+const EnterprisePage = () => (
+  <IntlProvider locale="en">
+    <Layout>
+      <div className="container">
+        <div className="row">
+          <div className="col-6">
+            <h1>Enterprise Page</h1>
+            <p>
+              Note: This page intentionally left blank and will be added to in additional PRs based on this branch. This is due to the refactoring of shared components that will come in a later PR.
+            </p>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  </IntlProvider>
+);
+export default withAuthentication(EnterprisePage);


### PR DESCRIPTION
This PR updates how pages are created during the Gatsby build to properly support both Enterprise and Programs page(s). In the end, this will not impact how pages for Masters (i.., programs, program list) are ultimately created; this is confirmed through the tests that @christopappas added.

Note: The EnterprisePage component is intentionally left sparse as the work for its UI will come in additional PR(s) (due to moving some components, e.g. course section, into the `common` folder).