### PR TITLE
ENT-2152 - Refactor withAuthentication to support both SAML SSO and direct login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3233,6 +3233,11 @@
         "supports-color": "^5.3.0"
       }
     },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -6672,8 +6677,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6691,13 +6695,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6710,18 +6712,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6824,8 +6823,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6835,7 +6833,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6848,20 +6845,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6878,7 +6872,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6951,8 +6944,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6962,7 +6954,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7038,8 +7029,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7069,7 +7059,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7087,7 +7076,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7126,13 +7114,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -7430,6 +7416,11 @@
             "invert-kv": "^2.0.0"
           }
         },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
         "make-dir": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -7576,24 +7567,18 @@
         "prop-types": "^15.6.1"
       }
     },
-    "gatsby-plugin-env-variables": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-env-variables/-/gatsby-plugin-env-variables-1.0.1.tgz",
-      "integrity": "sha512-TnXU+IjvM3iHcaNOa+alqP3Wk19+pmxvXwMyoPaUZIDKNwvpXRz8klsag2AwNlsqD17949/m8I80z8plZRyE1w=="
-    },
-    "gatsby-plugin-page-creator": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.0.12.tgz",
-      "integrity": "sha512-Pb4jpcI4Fqr6pqDdwm1+8DsyesZwBcvoQyDDvLBF+hbWD33iURjBqTrL8quTNtIO4svLkfieIdQ8D4IhlpFCmw==",
+    "gatsby-page-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.5.tgz",
+      "integrity": "sha512-yHL4OKgVEOWOuTUCO2ZPPmWyA1bAtSUPrf+W5w3p24pUwqMkz2Yu2hii/PhgQs+2ap6BkpSwBjBSYS2YLRmTNg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "bluebird": "^3.5.0",
         "chokidar": "2.1.2",
         "fs-exists-cached": "^1.0.0",
         "glob": "^7.1.1",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.14",
         "micromatch": "^3.1.10",
-        "parse-filepath": "^1.0.1",
         "slash": "^1.0.0"
       },
       "dependencies": {
@@ -7602,6 +7587,25 @@
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         }
+      }
+    },
+    "gatsby-plugin-env-variables": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-env-variables/-/gatsby-plugin-env-variables-1.0.1.tgz",
+      "integrity": "sha512-TnXU+IjvM3iHcaNOa+alqP3Wk19+pmxvXwMyoPaUZIDKNwvpXRz8klsag2AwNlsqD17949/m8I80z8plZRyE1w=="
+    },
+    "gatsby-plugin-page-creator": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.5.tgz",
+      "integrity": "sha512-nUcsaJAaMy9UQS66QY0Dys6Xx+2CGG2EVyvDQ4NQ713la62jicOU764Bmi5G7sE2QGgpNoBtUQCW+aE6UMGpLQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "bluebird": "^3.5.0",
+        "fs-exists-cached": "^1.0.0",
+        "gatsby-page-utils": "^0.0.5",
+        "glob": "^7.1.1",
+        "lodash": "^4.17.14",
+        "micromatch": "^3.1.10"
       }
     },
     "gatsby-plugin-react-helmet": {
@@ -8710,15 +8714,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
-    },
-    "is-absolute": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-      "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
-      }
     },
     "is-absolute-url": {
       "version": "2.1.0",
@@ -10241,9 +10236,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -10325,9 +10320,9 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.mergewith": {
@@ -10912,9 +10907,9 @@
       "integrity": "sha512-mUDCnVNsAi+eD6qA0HkRkwYczbLHJ49z17BGe2PYRhZL4wpZUFZGJHU7/5tmvohoma+Hdn0Vh/oJTiPEmgSruA=="
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -11957,16 +11952,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-filepath": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
-      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
-      "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
-      }
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -12050,19 +12035,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-    },
-    "path-root": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-      "requires": {
-        "path-root-regex": "^0.1.0"
-      }
-    },
-    "path-root-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -13574,6 +13546,45 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "recompose": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
+      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "change-emitter": "^0.1.2",
+        "fbjs": "^0.8.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "react-lifecycles-compat": "^3.0.2",
+        "symbol-observable": "^1.0.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
@@ -14469,9 +14480,9 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -16141,35 +16152,14 @@
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-router": "^4.3.1",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.9",
+    "recompose": "^0.30.0",
     "redux": "^4.0.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-logger": "^3.0.6",

--- a/src/components/common/with-authentication/index.js
+++ b/src/components/common/with-authentication/index.js
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
-export { default as withAuthentication } from './withAuthentication';
+export { default as withSamlSso } from './withSamlSso';
+export { default as withDirectLogin } from './withDirectLogin';

--- a/src/components/common/with-authentication/tests/withAuthentication.test.jsx
+++ b/src/components/common/with-authentication/tests/withAuthentication.test.jsx
@@ -24,12 +24,11 @@ apiClient.ensurePublicOrAuthenticationAndCookies = (_, callback) => {
 
 describe('<withAuthentication />', () => {
   it('does not render anything on initial paint', () => {
-    process.env.IDP_SLUG = 'saml-default';
     const MyComponent = () => <div />;
     const AuthenticatedComponent = withAuthentication(MyComponent);
     const wrapper = mount((
       <Provider store={store}>
-        <AuthenticatedComponent location={{ pathname: '/' }} />
+        <AuthenticatedComponent location={{ pathname: '/' }} loginUrl="http://www.edx.org" />
       </Provider>
     ));
     expect(wrapper.html()).toBeNull();

--- a/src/components/common/with-authentication/withAuthentication.jsx
+++ b/src/components/common/with-authentication/withAuthentication.jsx
@@ -25,7 +25,7 @@ const withAuthentication = (WrappedComponent) => {
         pathname: PropTypes.string.isRequired,
       }).isRequired,
       fetchUserAccount: PropTypes.func.isRequired,
-      providerSlug: PropTypes.string.isRequired,
+      loginUrl: PropTypes.string.isRequired,
       username: PropTypes.string,
     };
 
@@ -39,36 +39,23 @@ const withAuthentication = (WrappedComponent) => {
 
     componentDidMount() {
       const {
-        username, location, fetchUserAccount, providerSlug,
+        username, location, fetchUserAccount, loginUrl,
       } = this.props;
 
-      if (!providerSlug) {
-        apiClient.loginUrl = `${process.env.LMS_BASE_URL}/login`;
-        apiClient.ensurePublicOrAuthenticationAndCookies(location.pathname, async () => {
-          this.configure();
+      apiClient.loginUrl = loginUrl;
+      apiClient.ensurePublicOrAuthenticationAndCookies(location.pathname, async (accessToken) => {
+        this.configure();
 
-          await fetchUserAccount(userAccountApiService, username);
+        await fetchUserAccount(userAccountApiService, username);
 
-          identifyAuthenticatedUser();
-          sendPageEvent();
-          this.setState({ isLoading: false });
-        });
-      } else {
-        apiClient.loginUrl = `${process.env.LMS_BASE_URL}/auth/idp_redirect/${providerSlug}`;
-        apiClient.ensurePublicOrAuthenticationAndCookies(location.pathname, async (accessToken) => {
-          this.configure();
-
-          await fetchUserAccount(userAccountApiService, username);
-
-          if (accessToken) {
-            identifyAuthenticatedUser(accessToken.user_id);
-          } else {
-            identifyAnonymousUser();
-          }
-          sendPageEvent();
-          this.setState({ isLoading: false });
-        });
-      }
+        if (accessToken) {
+          identifyAuthenticatedUser(accessToken.user_id);
+        } else {
+          identifyAnonymousUser();
+        }
+        sendPageEvent();
+        this.setState({ isLoading: false });
+      });
     }
 
     configure() {
@@ -101,11 +88,7 @@ const withAuthentication = (WrappedComponent) => {
 
 withAuthentication.propTypes = {
   location: PropTypes.string.isRequired,
-  providerSlug: PropTypes.string.isRequired,
+  loginUrl: PropTypes.string.isRequired,
 };
 
-const withSaml = WrappedComponent => (
-  props => <WrappedComponent providerSlug={process.env.IDP_SLUG} {...props} />
-);
-
-export default WrappedComponent => withSaml(withAuthentication(WrappedComponent));
+export default withAuthentication;

--- a/src/components/common/with-authentication/withDirectLogin.jsx
+++ b/src/components/common/with-authentication/withDirectLogin.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { compose } from 'recompose';
+import withAuthentication from './withAuthentication';
+
+const withDirectLogin = WrappedComponent => (
+  props => (<WrappedComponent
+    loginUrl={`${process.env.LMS_BASE_URL}/login`}
+    {...props}
+  />)
+);
+
+export default compose(
+  withDirectLogin,
+  withAuthentication,
+);

--- a/src/components/common/with-authentication/withSamlSso.jsx
+++ b/src/components/common/with-authentication/withSamlSso.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { compose } from 'recompose';
+import withAuthentication from './withAuthentication';
+
+const withSamlSso = WrappedComponent => (
+  props => (<WrappedComponent
+    loginUrl={`${process.env.LMS_BASE_URL}/auth/idp_redirect/${process.env.IDP_SLUG}`}
+    {...props}
+  />)
+);
+
+export default compose(
+  withSamlSso,
+  withAuthentication,
+);

--- a/src/components/enterprise/dashboard/DashboardPage.jsx
+++ b/src/components/enterprise/dashboard/DashboardPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { withAuthentication } from '../../common/with-authentication';
+import { withDirectLogin } from '../../common/with-authentication';
 import { Layout, MainContent, Sidebar } from '../../common/layout';
 import { Hero } from '../../common/hero';
 import { DashboardMainContent } from './main-content';
@@ -31,4 +31,4 @@ DashboardPage.propTypes = {
   pageContext: PropTypes.shape({}).isRequired,
 };
 
-export default withAuthentication(DashboardPage);
+export default withDirectLogin(DashboardPage);

--- a/src/components/masters/program/ProgramPage.jsx
+++ b/src/components/masters/program/ProgramPage.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { compose } from 'recompose';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
@@ -8,7 +9,7 @@ import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { Hero } from '../../common/hero';
-import { withAuthentication } from '../../common/with-authentication';
+import { withSamlSso } from '../../common/with-authentication';
 import { Layout, MainContent, Sidebar } from '../../common/layout';
 import { LoadingSpinner } from '../../common/loading-spinner';
 import { ProgramMainContent } from './main-content';
@@ -168,6 +169,12 @@ const mapDispatchToProps = dispatch => ({
   fetchUserProgramEnrollments: () => dispatch(fetchUserProgramEnrollments()),
 });
 
-const authenticatedProgramPage = withAuthentication(ProgramPage);
+const ConnectedProgramPage = compose(
+  withSamlSso,
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+)(ProgramPage);
 
-export default connect(mapStateToProps, mapDispatchToProps)(authenticatedProgramPage);
+export default ConnectedProgramPage;

--- a/src/components/masters/programs-list/ProgramListPage.jsx
+++ b/src/components/masters/programs-list/ProgramListPage.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { compose } from 'recompose';
 import { navigate } from 'gatsby';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -6,7 +7,7 @@ import { StatusAlert } from '@edx/paragon';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { withAuthentication } from '../../common/with-authentication';
+import { withSamlSso } from '../../common/with-authentication';
 import { Layout } from '../../common/layout';
 import { LoadingSpinner } from '../../common/loading-spinner';
 
@@ -187,9 +188,12 @@ const mapDispatchToProps = dispatch => ({
   fetchUserProgramEnrollments: () => dispatch(fetchUserProgramEnrollments()),
 });
 
-const ConnectedProgramListPage = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(withAuthentication(ProgramListPage));
+const ConnectedProgramListPage = compose(
+  withSamlSso,
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+)(ProgramListPage);
 
 export default ConnectedProgramListPage;


### PR DESCRIPTION
This PR extracts the common logic of withAuthentication and creates HOCs for SAML SSO and direct login capabilities. These two HOCs are then used to wrap the Program and Enterprise pages respectively.