### PR TITLE
Always create program list page

### DIFF
--- a/plugins/gatsby-source-wagtail/createPagesWithData.js
+++ b/plugins/gatsby-source-wagtail/createPagesWithData.js
@@ -46,9 +46,10 @@ function createPagesWithData(result, actions) {
       return { ...commonPageContext, ...pageContext };
     });
 
-  // If we spot an enterprise page, create it, and do not create programs pages
+  // If we spot an enterprise page, create it, and do not create program-related pages
   const firstPageData = allPagesData && allPagesData[0];
   const isEnterprise = firstPageData && firstPageData.pageType === 'pages.EnterprisePage';
+
   if (isEnterprise) {
     createPage({
       path: '/',
@@ -56,17 +57,18 @@ function createPagesWithData(result, actions) {
       context: firstPageData,
     });
   } else {
-    // Create landing page if there are multiple programs pages
     const programs = allPagesData.filter(node => node.pageType === 'pages.ProgramPage');
-    if (programs && programs.length > 1) {
-      createPage({
-        path: '/',
-        component: templates.programListPage,
-        context: { programs },
-      });
-    }
+    // Create the program listing page. This page must exist as it
+    // handles the redirect to an individual program in the case where
+    // only one program exists and the user goes to the `/` path.
+    createPage({
+      path: '/',
+      component: templates.programListPage,
+      context: { programs },
+    });
+
     // Create Gatsby pages for each page from portal-designer so long as
-    // we are not only building the listings
+    // we are not only building the program listing page.
     if (!onlyCreateListingPage) {
       programs.forEach((pageData) => {
         createPage({

--- a/plugins/gatsby-source-wagtail/test/createPagesWithData.test.js
+++ b/plugins/gatsby-source-wagtail/test/createPagesWithData.test.js
@@ -50,7 +50,7 @@ describe('createPagesWithData', () => {
     expect(actions.createPage).toBeCalledWith({ ...expectedArgs });
   });
 
-  it('should only create a single programPage if only one programPage is present', () => {
+  it('should create both a single program page and program list page if only one program page node is present', () => {
     const graphqlQueryResult = {
       data: {
         allPage: {
@@ -85,25 +85,33 @@ describe('createPagesWithData', () => {
 
     createPagesWithData(graphqlQueryResult, actions);
 
-    const expectedArgs = {
+    const programPageData = {
+      pageType: 'pages.ProgramPage',
+      pageBranding: {},
+      programSlug: 'prog-slug',
+      programUUID: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+      programName: 'The best program ever',
+      programHostname: null,
+      programDocuments: null,
+      externalProgramWebsite: null,
+    };
+    const expectedProgramPageArgs = {
       path: 'prog-slug',
       component: templates.programPage,
-      context: {
-        pageType: 'pages.ProgramPage',
-        pageBranding: {},
-        programSlug: 'prog-slug',
-        programUUID: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
-        programName: 'The best program ever',
-        programHostname: null,
-        programDocuments: null,
-        externalProgramWebsite: null,
-      },
+      context: programPageData,
     };
-    expect(actions.createPage.mock.calls.length).toEqual(1);
-    expect(actions.createPage).toBeCalledWith({ ...expectedArgs });
+    const expectedProgramListPageArgs = {
+      path: '/',
+      component: templates.programListPage,
+      context: { programs: [programPageData] },
+    };
+
+    expect(actions.createPage.mock.calls.length).toEqual(2);
+    expect(actions.createPage).toBeCalledWith(expectedProgramListPageArgs);
+    expect(actions.createPage).toBeCalledWith(expectedProgramPageArgs);
   });
 
-  it('should create list page if multiple programsPage nodes exist.', () => {
+  it('should create list page if multiple program pages nodes exist.', () => {
     const graphqlQueryResult = {
       data: {
         allPage: {


### PR DESCRIPTION
Because the program list page component handles the redirect to individual program page, it always need to exist even when only 1 program exists. This PR fixes that logic to ensure that page is always created during build, except in the case where an enterprise page was created first.