### PR TITLE
Create reusable loading spinner component

### DIFF
--- a/src/components/common/loading-spinner/LoadingSpinner.jsx
+++ b/src/components/common/loading-spinner/LoadingSpinner.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LoadingSpinner = (props) => {
+  const { screenReaderText } = props;
+  return (
+    <div className="d-flex justify-content-center align-items-center">
+      <div className="spinner-border text-primary" role="status">
+        <span className="sr-only">{screenReaderText}</span>
+      </div>
+    </div>
+  );
+};
+
+LoadingSpinner.propTypes = {
+  screenReaderText: PropTypes.string.isRequired,
+};
+
+export default LoadingSpinner;

--- a/src/components/common/loading-spinner/index.js
+++ b/src/components/common/loading-spinner/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as LoadingSpinner } from './LoadingSpinner';

--- a/src/components/masters/program/ProgramPage.jsx
+++ b/src/components/masters/program/ProgramPage.jsx
@@ -16,6 +16,7 @@ import { ProgramSidebar } from './sidebar';
 import { fetchUserProgramEnrollments } from '../user-program-enrollments';
 
 import './styles/ProgramPage.scss';
+import { LoadingSpinner } from '../../common/loading-spinner';
 
 class ProgramPage extends Component {
   constructor(props) {
@@ -80,11 +81,7 @@ class ProgramPage extends Component {
     return (
       <Layout pageContext={pageContext}>
         {isLoading ? (
-          <div className="d-flex justify-content-center align-items-center" style={{ height: 200 }}>
-            <div className="spinner-border text-primary" role="status">
-              <div className="sr-only">Loading program enrollments...</div>
-            </div>
-          </div>
+          <LoadingSpinner screenReaderText="loading program enrollments" />
         ) : (
           <>
             {hasProgramAccess ? (

--- a/src/components/masters/program/ProgramPage.jsx
+++ b/src/components/masters/program/ProgramPage.jsx
@@ -10,13 +10,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Hero } from '../../common/hero';
 import { withAuthentication } from '../../common/with-authentication';
 import { Layout, MainContent, Sidebar } from '../../common/layout';
+import { LoadingSpinner } from '../../common/loading-spinner';
 import { ProgramMainContent } from './main-content';
 import { ProgramSidebar } from './sidebar';
 
 import { fetchUserProgramEnrollments } from '../user-program-enrollments';
 
 import './styles/ProgramPage.scss';
-import { LoadingSpinner } from '../../common/loading-spinner';
 
 class ProgramPage extends Component {
   constructor(props) {

--- a/src/components/masters/program/main-content/ProgramMainContent.jsx
+++ b/src/components/masters/program/main-content/ProgramMainContent.jsx
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { breakpoints, StatusAlert } from '@edx/paragon';
 
 import { LayoutContext } from '../../../common/layout';
+import { LoadingSpinner } from '../../../common/loading-spinner';
 import ProgramSidebar from '../sidebar/ProgramSidebar';
 import CourseSection from './CourseSection';
 import {
@@ -72,14 +73,6 @@ class MainContent extends Component {
     />
   );
 
-  renderLoading = () => (
-    <div className="d-flex justify-content-center align-items-center">
-      <div className="spinner-border text-primary" role="status">
-        <div className="sr-only">Loading program enrollments...</div>
-      </div>
-    </div>
-  );
-
   renderCourseSections = () => {
     const courses = this.groupCourseEnrollmentsByStatus();
     return (
@@ -115,7 +108,7 @@ class MainContent extends Component {
     if (error) {
       return this.renderError();
     } else if (isLoading) {
-      return this.renderLoading();
+      return <LoadingSpinner screenReaderText="loading course enrollments for program" />;
     }
     return this.renderCourseSections();
   }

--- a/src/components/masters/program/main-content/tests/__snapshots__/ProgramMainContent.test.jsx.snap
+++ b/src/components/masters/program/main-content/tests/__snapshots__/ProgramMainContent.test.jsx.snap
@@ -47,11 +47,11 @@ exports[`<ProgramMainContent /> renders correctly with loading state 1`] = `
     className="spinner-border text-primary"
     role="status"
   >
-    <div
+    <span
       className="sr-only"
     >
-      Loading program enrollments...
-    </div>
+      loading course enrollments for program
+    </span>
   </div>
 </div>
 `;

--- a/src/components/masters/programs-list/ProgramListPage.jsx
+++ b/src/components/masters/programs-list/ProgramListPage.jsx
@@ -10,6 +10,7 @@ import { withAuthentication } from '../../common/with-authentication';
 import { Layout } from '../../common/layout';
 
 import { fetchUserProgramEnrollments } from '../user-program-enrollments';
+import { LoadingSpinner } from '../../common/loading-spinner';
 
 export class ProgramListPage extends Component {
   constructor(props) {
@@ -91,13 +92,7 @@ export class ProgramListPage extends Component {
       <>
         {isLoading ? (
           <Layout>
-            <div className="container my-4">
-              <div className="d-flex justify-content-center align-items-center" style={{ height: 200 }}>
-                <div className="spinner-border text-primary" role="status">
-                  <div className="sr-only">Loading program enrollments...</div>
-                </div>
-              </div>
-            </div>
+            <LoadingSpinner screenReaderText="loading program enrollments" />
           </Layout>
         ) : (
           <>

--- a/src/components/masters/programs-list/ProgramListPage.jsx
+++ b/src/components/masters/programs-list/ProgramListPage.jsx
@@ -8,9 +8,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { withAuthentication } from '../../common/with-authentication';
 import { Layout } from '../../common/layout';
+import { LoadingSpinner } from '../../common/loading-spinner';
 
 import { fetchUserProgramEnrollments } from '../user-program-enrollments';
-import { LoadingSpinner } from '../../common/loading-spinner';
 
 export class ProgramListPage extends Component {
   constructor(props) {

--- a/src/components/masters/programs-list/tests/__snapshots__/ProgramListPage.test.jsx.snap
+++ b/src/components/masters/programs-list/tests/__snapshots__/ProgramListPage.test.jsx.snap
@@ -16,26 +16,17 @@ Array [
     id="content"
   >
     <div
-      className="container my-4"
+      className="d-flex justify-content-center align-items-center"
     >
       <div
-        className="d-flex justify-content-center align-items-center"
-        style={
-          Object {
-            "height": 200,
-          }
-        }
+        className="spinner-border text-primary"
+        role="status"
       >
-        <div
-          className="spinner-border text-primary"
-          role="status"
+        <span
+          className="sr-only"
         >
-          <div
-            className="sr-only"
-          >
-            Loading program enrollments...
-          </div>
-        </div>
+          loading program enrollments
+        </span>
       </div>
     </div>
   </main>,


### PR DESCRIPTION
We use the same loading spinner in several places throughout the program-related pages, and will also want to reuse it for enterprise-related pages. This PR creates a `LoadingSpinner` component that is now reused in program-related pages, and can be used for enterprise pages.

It accepts a required `screenReaderText` prop for a11y.