### PR TITLE
Refactor enterprise folder structure

### DIFF
--- a/plugins/gatsby-source-wagtail/createPagesWithData.js
+++ b/plugins/gatsby-source-wagtail/createPagesWithData.js
@@ -53,7 +53,7 @@ function createPagesWithData(result, actions) {
   if (isEnterprise) {
     createPage({
       path: '/',
-      component: templates.enterprisePage,
+      component: templates.enterpriseDashboardPage,
       context: firstPageData,
     });
   } else {

--- a/plugins/gatsby-source-wagtail/templates.js
+++ b/plugins/gatsby-source-wagtail/templates.js
@@ -3,7 +3,7 @@ const path = require('path');
 const templates = {
   programListPage: path.resolve('./src/components/masters/programs-list/ProgramListPage.jsx'),
   programPage: path.resolve('./src/components/masters/program/ProgramPage.jsx'),
-  enterprisePage: path.resolve('./src/components/enterprise/EnterprisePage.jsx'),
+  enterpriseDashboardPage: path.resolve('./src/components/enterprise/dashboard/DashboardPage.jsx'),
 };
 
 exports.templates = templates;

--- a/plugins/gatsby-source-wagtail/test/createPagesWithData.test.js
+++ b/plugins/gatsby-source-wagtail/test/createPagesWithData.test.js
@@ -39,7 +39,7 @@ describe('createPagesWithData', () => {
 
     const expectedArgs = {
       path: '/',
-      component: templates.enterprisePage,
+      component: templates.enterpriseDashboardPage,
       context: {
         pageType: 'pages.EnterprisePage',
         pageBranding: {},

--- a/src/components/enterprise/dashboard/DashboardPage.jsx
+++ b/src/components/enterprise/dashboard/DashboardPage.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { withAuthentication } from '../common/with-authentication';
-import { Layout, MainContent, Sidebar } from '../common/layout';
-import { Hero } from '../common/hero';
+import { withAuthentication } from '../../common/with-authentication';
+import { Layout, MainContent, Sidebar } from '../../common/layout';
+import { Hero } from '../../common/hero';
+import { DashboardMainContent } from './main-content';
+import { DashboardSidebar } from './sidebar';
 
-const EnterprisePage = (props) => {
+const DashboardPage = (props) => {
   const { pageContext } = props;
   const { enterpriseName } = pageContext;
   return (
@@ -14,10 +16,10 @@ const EnterprisePage = (props) => {
       <div className="container py-5">
         <div className="row">
           <MainContent>
-            <p>Main Content</p>
+            <DashboardMainContent />
           </MainContent>
           <Sidebar>
-            <p>Sidebar</p>
+            <DashboardSidebar />
           </Sidebar>
         </div>
       </div>
@@ -25,8 +27,8 @@ const EnterprisePage = (props) => {
   );
 };
 
-EnterprisePage.propTypes = {
+DashboardPage.propTypes = {
   pageContext: PropTypes.shape({}).isRequired,
 };
 
-export default withAuthentication(EnterprisePage);
+export default withAuthentication(DashboardPage);

--- a/src/components/enterprise/dashboard/main-content/DashboardMainContent.jsx
+++ b/src/components/enterprise/dashboard/main-content/DashboardMainContent.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const DashboardMainContent = () => (
+  <p>Main Content</p>
+);
+
+export default DashboardMainContent;

--- a/src/components/enterprise/dashboard/main-content/index.js
+++ b/src/components/enterprise/dashboard/main-content/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as DashboardMainContent } from './DashboardMainContent';

--- a/src/components/enterprise/dashboard/sidebar/DashboardSidebar.jsx
+++ b/src/components/enterprise/dashboard/sidebar/DashboardSidebar.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const DashboardSidebar = () => (
+  <p>Sidebar</p>
+);
+
+export default DashboardSidebar;

--- a/src/components/enterprise/dashboard/sidebar/index.js
+++ b/src/components/enterprise/dashboard/sidebar/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as DashboardSidebar } from './DashboardSidebar';


### PR DESCRIPTION
This PR adds the initial folder structure for the enterprise pages. It also updates the Gatsby plugin to use the correct template (DashboardPage.jsx) for the root path.