### PR TITLE
Allow for redirect to another deployment

### DIFF
--- a/src/components/masters/programs-list/ProgramListPage.jsx
+++ b/src/components/masters/programs-list/ProgramListPage.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { compose } from 'recompose';
-import { navigate } from 'gatsby';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { StatusAlert } from '@edx/paragon';
@@ -43,7 +42,7 @@ export class ProgramListPage extends Component {
 
       if (validEnrolledPrograms.length === 1) {
         const program = validEnrolledPrograms[0];
-        navigate(`${program.slug}`);
+        window.location.replace(`/${program.hostname}/${program.slug}`);
       } else {
         // eslint-disable-next-line react/no-did-update-set-state
         this.setState({


### PR DESCRIPTION
Program list page would only redirect to program in it's own deployment,
which broke for the unbranded deployment. Now it takes hostname into
account