### PR TITLE
Add container for program list table

### DIFF
--- a/src/components/masters/programs-list/ProgramListPage.jsx
+++ b/src/components/masters/programs-list/ProgramListPage.jsx
@@ -111,7 +111,7 @@ export class ProgramListPage extends Component {
                 {validPrograms && (
                   <Layout>
                     {!validPrograms.length ? (
-                      <div className="my-3 container">
+                      <div className="container my-3">
                         {this.renderError({
                           message: (
                             <>
@@ -126,7 +126,7 @@ export class ProgramListPage extends Component {
                         })}
                       </div>
                     ) : (
-                      <>
+                      <div className="container my-3">
                         <h1>My Programs</h1>
                         <div className="table-responsive mt-3">
                           <table className="table table-sm table-striped">
@@ -144,7 +144,7 @@ export class ProgramListPage extends Component {
                             </tbody>
                           </table>
                         </div>
-                      </>
+                      </div>
                     )}
                   </Layout>
                 )}


### PR DESCRIPTION
I noticed that the program list table was not being rendered in a Bootstrap `.container` class, such that its contents were stretched across the full width of the screen.

This PR adds in the `.container` class to the program list table view.

![image](https://user-images.githubusercontent.com/2828721/63819310-c9939f00-c912-11e9-80fe-bbda1fd827bf.png)
