### PR TITLE
Pass in course status to BaseCourseCard to determine appropriate date message

### DIFF
--- a/src/components/common/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/common/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -45,25 +45,31 @@ class BaseCourseCard extends Component {
     return dropdownMenuItems;
   };
 
-  getStartDateMessage = () => {
-    const { pacing, startDate, endDate } = this.props;
+  getDateMessage = () => {
+    const { type, pacing, endDate } = this.props;
+    const formattedEndDate = endDate ? moment(endDate).format('MMMM D, YYYY') : null;
     let message = '';
-    if (pacing === 'self') {
-      const formattedEndDate = moment(endDate).format('MMMM D, YYYY');
-      message += `Complete at your own speed before ${formattedEndDate}.`;
-    } else {
-      const formattedStartDate = moment(startDate).format('MMMM D, YYYY');
-      const formattedStartString = this.isCourseEnded() ? 'Ended' : 'Ends';
-      message += `${formattedStartString} ${formattedStartDate}.`;
+    switch (type) {
+      case 'in_progress': {
+        if (pacing === 'self') {
+          message += `Complete at your own speed before ${formattedEndDate}.`;
+        } else {
+          message += `Ends ${formattedEndDate}.`;
+        }
+        break;
+      }
+      case 'upcoming': {
+        message += `Ends ${formattedEndDate}.`;
+        break;
+      }
+      case 'completed': {
+        message += `Ended ${formattedEndDate}.`;
+        break;
+      }
+      default:
+        break;
     }
     return message;
-  };
-
-  getEndDateMessage = () => {
-    const { endDate } = this.props;
-    const formattedEndDate = moment(endDate).format('MMMM D, YYYY');
-    const formattedEndString = this.isCourseEnded() ? 'Ended' : 'Ends';
-    return `${formattedEndString} ${formattedEndDate}.`;
   };
 
   getCourseMiscText = () => {
@@ -75,11 +81,7 @@ class BaseCourseCard extends Component {
       message += isCourseEnded ? 'was ' : 'is ';
       message += `${pacing}-paced. `;
     }
-    if (isCourseEnded) {
-      message += this.getEndDateMessage();
-    } else {
-      message += this.getStartDateMessage();
-    }
+    message += this.getDateMessage();
     return message;
   };
 
@@ -98,7 +100,7 @@ class BaseCourseCard extends Component {
   isCourseEnded = () => {
     const { endDate } = this.props;
     return moment(endDate) < moment();
-  }
+  };
 
   handleEmailSettingsButtonClick = () => {
     const {
@@ -119,7 +121,7 @@ class BaseCourseCard extends Component {
       },
     });
     sendTrackEvent('edx.learner_portal.email_settings_modal.opened', { course_run_id: courseRunId });
-  }
+  };
 
   handleEmailSettingsModalOnClose = (hasEmailsEnabled) => {
     this.resetModals();
@@ -158,7 +160,7 @@ class BaseCourseCard extends Component {
       );
     }
     return null;
-  }
+  };
 
   renderEmailSettingsModal = () => {
     const { hasEmailsEnabled, courseRunId } = this.props;
@@ -216,7 +218,7 @@ class BaseCourseCard extends Component {
       );
     }
     return null;
-  }
+  };
 
   renderButtons = () => {
     const { buttons } = this.props;
@@ -298,6 +300,9 @@ class BaseCourseCard extends Component {
 }
 
 BaseCourseCard.propTypes = {
+  type: PropTypes.oneOf([
+    'in_progress', 'upcoming', 'completed',
+  ]).isRequired,
   title: PropTypes.string.isRequired,
   linkToCourse: PropTypes.string.isRequired,
   courseRunId: PropTypes.string.isRequired,

--- a/src/components/common/course-enrollments/course-cards/CompletedCourseCard.jsx
+++ b/src/components/common/course-enrollments/course-cards/CompletedCourseCard.jsx
@@ -7,7 +7,7 @@ import BaseCourseCard from './BaseCourseCard';
 import CertificateImg from './images/edx-verified-mini-cert.png';
 
 const CompletedCourseCard = props => (
-  <BaseCourseCard hasViewCertificateLink={false} {...props}>
+  <BaseCourseCard type="completed" hasViewCertificateLink={false} {...props}>
     {props.linkToCertificate ? (
       <div className="d-flex">
         <div className="mr-3">

--- a/src/components/common/course-enrollments/course-cards/InProgressCourseCard.jsx
+++ b/src/components/common/course-enrollments/course-cards/InProgressCourseCard.jsx
@@ -27,7 +27,7 @@ const InProgressCourseCard = (props) => {
   });
 
   return (
-    <BaseCourseCard buttons={renderButtons()} {...props}>
+    <BaseCourseCard type="in_progress" buttons={renderButtons()} {...props}>
       {filteredNotifications.length > 0 && (
         <div className="notifications">
           <ul className="list-unstyled mb-0" aria-label="course due dates" role="alert">

--- a/src/components/common/course-enrollments/course-cards/UpcomingCourseCard.jsx
+++ b/src/components/common/course-enrollments/course-cards/UpcomingCourseCard.jsx
@@ -12,7 +12,7 @@ const UpcomingCourseCard = (props) => {
   );
 
   return (
-    <BaseCourseCard buttons={renderButtons()} {...props} />
+    <BaseCourseCard type="upcoming" buttons={renderButtons()} {...props} />
   );
 };
 


### PR DESCRIPTION
Before, we were using whether or not the course has ended based on the supplied `endDate` of a course to determine the date message text in the course cards. We were incorrectly displaying "Ends <startDate>" for `in_progress` course cards when it should have been displaying "Ends <endDate>".

To make this logic more explicit, I am now passing in a `type` prop to `BaseCourseCard` for each of the 3 course card variations (in progress, upcoming, completed) and having the date message be based on the type of the card instead. This makes it a bit clearer what is going in in the code as well.