### PR TITLE
Only include end date in text if it exists

### DIFF
--- a/src/components/common/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/common/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -49,25 +49,27 @@ class BaseCourseCard extends Component {
     const { type, pacing, endDate } = this.props;
     const formattedEndDate = endDate ? moment(endDate).format('MMMM D, YYYY') : null;
     let message = '';
-    switch (type) {
-      case 'in_progress': {
-        if (pacing === 'self') {
-          message += `Complete at your own speed before ${formattedEndDate}.`;
-        } else {
-          message += `Ends ${formattedEndDate}.`;
+    if (formattedEndDate) {
+      switch (type) {
+        case 'in_progress': {
+          if (pacing === 'self') {
+            message += `Complete at your own speed before ${formattedEndDate}.`;
+          } else {
+            message += `Ends ${formattedEndDate}.`;
+          }
+          break;
         }
-        break;
+        case 'upcoming': {
+          message += `Ends ${formattedEndDate}.`;
+          break;
+        }
+        case 'completed': {
+          message += `Ended ${formattedEndDate}.`;
+          break;
+        }
+        default:
+          break;
       }
-      case 'upcoming': {
-        message += `Ends ${formattedEndDate}.`;
-        break;
-      }
-      case 'completed': {
-        message += `Ended ${formattedEndDate}.`;
-        break;
-      }
-      default:
-        break;
     }
     return message;
   };
@@ -75,13 +77,16 @@ class BaseCourseCard extends Component {
   getCourseMiscText = () => {
     const { pacing } = this.props;
     const isCourseEnded = this.isCourseEnded();
+    const dateMessage = this.getDateMessage();
     let message = '';
     if (pacing) {
       message += 'This course ';
       message += isCourseEnded ? 'was ' : 'is ';
       message += `${pacing}-paced. `;
     }
-    message += this.getDateMessage();
+    if (dateMessage) {
+      message += dateMessage;
+    }
     return message;
   };
 


### PR DESCRIPTION
For our course cards, we make an assumption that the course end date will always exist. However, it turns out the end date is a nullable field and might sometimes be empty.

This PR only renders text around the end date if an end date exists. This will prevent it from saying something like, "Ends null." when an end date is not present.

Note: I noticed this issue now that I have a valid program course enrollment on stage; the course card was saying "Ends null." Quick fix, so decided to open a PR for it :)