### PR TITLE
Revert temporary URL fix, as all LMS URLs are now absolute

### DIFF
--- a/src/components/common/course-enrollments/data/__mocks__/programCourseEnrollments.json
+++ b/src/components/common/course-enrollments/data/__mocks__/programCourseEnrollments.json
@@ -7,7 +7,6 @@
     "end_date": "2019-09-14T00:00:00Z",
     "display_name": "edX Demonstration Course",
     "course_run_url": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/course/",
-    "resume_course_run_url": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/course/",
     "due_dates": [
       {
         "name": "Assignment 1",

--- a/src/components/common/course-enrollments/data/__mocks__/programCourseEnrollments.json
+++ b/src/components/common/course-enrollments/data/__mocks__/programCourseEnrollments.json
@@ -7,6 +7,7 @@
     "end_date": "2019-09-14T00:00:00Z",
     "display_name": "edX Demonstration Course",
     "course_run_url": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/course/",
+    "resume_course_run_url": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/course/",
     "due_dates": [
       {
         "name": "Assignment 1",

--- a/src/components/common/course-enrollments/data/selectors.js
+++ b/src/components/common/course-enrollments/data/selectors.js
@@ -7,15 +7,6 @@ export const getError = state => state.courseEnrollments.error;
 const transformCourseRun = (originalCourseRun) => {
   const courseRun = { ...originalCourseRun };
 
-  // Note: This is a temporary fix to convert the value of
-  // `resumeCourseRunUrl` from a relative URL to absolute URL, only when the
-  // `resumeCourseRunUrl` is actually relative.
-  let { resumeCourseRunUrl } = courseRun;
-  if (resumeCourseRunUrl && (resumeCourseRunUrl.indexOf('://') === -1 || resumeCourseRunUrl.indexOf('//') !== 0)) {
-    // URL is relative; let's make it absolute!
-    resumeCourseRunUrl = `${process.env.LMS_BASE_URL}${resumeCourseRunUrl}`;
-  }
-
   // Return the fields expected by the component(s)
   courseRun.title = courseRun.displayName;
   courseRun.microMastersTitle = courseRun.micromastersTitle;
@@ -23,7 +14,7 @@ const transformCourseRun = (originalCourseRun) => {
   // present if the learner has made progress. If the learner has not made progress,
   // we should link to the main course run URL. Similarly, if the resume course link
   // is not set in the API response, we should fallback on the normal course link.
-  courseRun.linkToCourse = resumeCourseRunUrl || courseRun.courseRunUrl;
+  courseRun.linkToCourse = courseRun.resumeCourseRunUrl || courseRun.courseRunUrl;
   courseRun.linkToCertificate = courseRun.certificateDownloadUrl;
   courseRun.hasEmailsEnabled = courseRun.emailsEnabled;
   courseRun.notifications = courseRun.dueDates;


### PR DESCRIPTION
```
Revert "Temporary URL fix (#127)"

This reverts commit 7677060a2d4bdcf39d6773ae32e566b103aa7485.

https://github.com/edx/edx-platform/pull/21474 removes the
need to check for relative URLs from program_enrollments
API responses.
```
Reverts https://github.com/edx/frontend-app-learner-portal/pull/127
@adamstankiewicz 

(cc @edx/masters-neem )