### PR TITLE
ENT-2203 Thread through enterprise id from gatsby context to enrollments call

### DIFF
--- a/plugins/gatsby-source-wagtail/createPagesWithData.js
+++ b/plugins/gatsby-source-wagtail/createPagesWithData.js
@@ -28,6 +28,7 @@ const transformEnterprisePageContext = context => (
   {
     enterpriseName: context.title,
     enterpriseEmail: context.contact_email,
+    enterpriseUUID: context.uuid,
   }
 );
 

--- a/plugins/gatsby-source-wagtail/test/createPagesWithData.test.js
+++ b/plugins/gatsby-source-wagtail/test/createPagesWithData.test.js
@@ -44,6 +44,7 @@ describe('createPagesWithData', () => {
         pageType: 'pages.EnterprisePage',
         pageBranding: {},
         enterpriseName: 'Example Enterprise',
+        enterpriseUUID: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
       },
     };
     expect(actions.createPage.mock.calls.length).toEqual(1);

--- a/src/components/common/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/common/course-enrollments/CourseEnrollments.jsx
@@ -26,12 +26,15 @@ export class CourseEnrollments extends Component {
       pageContext: {
         pageType,
         programUUID, // for Masters, empty for Enterprise
+        enterpriseUUID,
       },
     } = this.context;
     const { fetchCourseEnrollments } = this.props;
     const options = { pageType };
     if (pageType === 'pages.ProgramPage') {
       options.programUUID = programUUID;
+    } else if (pageType === 'pages.EnterprisePage') {
+      options.enterpriseUUID = enterpriseUUID;
     }
     fetchCourseEnrollments(options);
   }

--- a/src/components/common/course-enrollments/data/actions.js
+++ b/src/components/common/course-enrollments/data/actions.js
@@ -41,7 +41,7 @@ export const fetchCourseEnrollments = options => (
     dispatch(fetchCourseEnrollmentsRequest());
     let serviceMethod;
     if (options.pageType === 'pages.EnterprisePage') {
-      serviceMethod = () => service.fetchEnterpriseCourseEnrollments();
+      serviceMethod = () => service.fetchEnterpriseCourseEnrollments(options.enterpriseUUID);
     } else {
       serviceMethod = () => service.fetchProgramCourseEnrollments(options.programUUID);
     }

--- a/src/components/common/course-enrollments/data/service.js
+++ b/src/components/common/course-enrollments/data/service.js
@@ -1,3 +1,4 @@
+import qs from 'query-string';
 import apiClient from '../../../../apiClient';
 
 export const fetchProgramCourseEnrollments = (programUUID) => {
@@ -5,7 +6,10 @@ export const fetchProgramCourseEnrollments = (programUUID) => {
   return apiClient.get(url);
 };
 
-export const fetchEnterpriseCourseEnrollments = () => {
-  const url = `${process.env.LMS_BASE_URL}/enterprise_learner_portal/api/v1/enterprise_course_enrollments/`;
+export const fetchEnterpriseCourseEnrollments = (enterpriseUUID) => {
+  const queryParams = {
+    enterprise_id: enterpriseUUID,
+  };
+  const url = `${process.env.LMS_BASE_URL}/enterprise_learner_portal/api/v1/enterprise_course_enrollments/?${qs.stringify(queryParams)}`;
   return apiClient.get(url);
 };

--- a/src/components/common/course-enrollments/tests/CourseEnrollments.test.jsx
+++ b/src/components/common/course-enrollments/tests/CourseEnrollments.test.jsx
@@ -189,8 +189,10 @@ describe('<CourseEnrollments />', () => {
     });
 
     it('for enterprise page', () => {
+      const enterpriseUUID = 'test-enterprise-uuid';
       const pageContext = {
         pageType: 'pages.EnterprisePage',
+        enterpriseUUID,
       };
       mount((
         <LayoutContext.Provider value={{ pageContext }}>
@@ -200,6 +202,7 @@ describe('<CourseEnrollments />', () => {
       expect(mockFetchCourseEnrollments.mock.calls.length).toEqual(1);
       expect(mockFetchCourseEnrollments).toBeCalledWith({
         pageType: 'pages.EnterprisePage',
+        enterpriseUUID,
       });
     });
   });


### PR DESCRIPTION
Since we've updated the enterprise enrollments api to require sending the enterprise id (https://github.com/edx/edx-enterprise/pull/561), we need to thread this variable through and update the api call tot return the proper results.