### PR TITLE
Change the API endpoint for updating course email settings

### DIFF
--- a/src/components/common/course-enrollments/course-cards/email-settings/data/service.js
+++ b/src/components/common/course-enrollments/course-cards/email-settings/data/service.js
@@ -5,9 +5,11 @@ import apiClient from '../../../../../../apiClient';
 const updateEmailSettings = (courseRunId, hasEmailsEnabled) => {
   const queryParams = {
     course_id: courseRunId,
-    email_opt_in: hasEmailsEnabled,
+    // If emails are enabled, the API endpoint expects the string "on";
+    // otherwise, the `receive_emails` field should be omitted.
+    receive_emails: hasEmailsEnabled ? 'on' : undefined,
   };
-  const emailSettingsUrl = `${process.env.LMS_BASE_URL}/user_api/v1/preferences/email_opt_in/`;
+  const emailSettingsUrl = `${process.env.LMS_BASE_URL}/change_email_settings/`;
   return apiClient.post(
     emailSettingsUrl,
     qs.stringify(queryParams),


### PR DESCRIPTION
Related ticket: https://openedx.atlassian.net/browse/ENT-2271

This PR swaps out our use of the `/user_api/v1/preferences/email_opt_in/` endpoint for the correct `/change_email_settings/` endpoint.