### PR TITLE
Remove "/" on API url

### DIFF
--- a/src/components/common/course-enrollments/course-cards/email-settings/data/service.js
+++ b/src/components/common/course-enrollments/course-cards/email-settings/data/service.js
@@ -9,7 +9,7 @@ const updateEmailSettings = (courseRunId, hasEmailsEnabled) => {
     // otherwise, the `receive_emails` field should be omitted.
     receive_emails: hasEmailsEnabled ? 'on' : undefined,
   };
-  const emailSettingsUrl = `${process.env.LMS_BASE_URL}/change_email_settings/`;
+  const emailSettingsUrl = `${process.env.LMS_BASE_URL}/change_email_settings`;
   return apiClient.post(
     emailSettingsUrl,
     qs.stringify(queryParams),


### PR DESCRIPTION
The `/change_email_settings` endpoint does not have a trailing slash like most of other endpoints we've hit in the past, causing a 404 when hitting the endpoint with the trailing slash.