### PR TITLE
Ensure `contact_email` comes through GraphQL

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -18,6 +18,7 @@ exports.createPages = async ({ graphql, actions }) => graphql(`
         type
         uuid
         hostname
+        contact_email
         program_documents {
           header
           display

--- a/plugins/gatsby-source-wagtail/schema/types.gql
+++ b/plugins/gatsby-source-wagtail/schema/types.gql
@@ -16,6 +16,7 @@ module.exports = `
       hostname: String
       type: String
       branding: branding
+      contact_email: String
       program_documents: program_documents
       external_program_website: external_program_website
   }

--- a/plugins/gatsby-source-wagtail/test/createPagesWithData.test.js
+++ b/plugins/gatsby-source-wagtail/test/createPagesWithData.test.js
@@ -17,6 +17,7 @@ describe('createPagesWithData', () => {
               program_documents: null,
               external_program_website: null,
               branding: {},
+              contact_email: 'hi@testorg.com',
             },
             {
               id: '0de66c11-6c9a-538b-aeb6-767f0013c96d',
@@ -28,6 +29,7 @@ describe('createPagesWithData', () => {
               program_documents: null,
               external_program_website: null,
               branding: {},
+              contact_email: null,
             },
           ],
         },
@@ -45,6 +47,7 @@ describe('createPagesWithData', () => {
         pageBranding: {},
         enterpriseName: 'Example Enterprise',
         enterpriseUUID: '47fc98b8-9a90-406d-854b-a4e91df0bc8c',
+        enterpriseEmail: 'hi@testorg.com',
       },
     };
     expect(actions.createPage.mock.calls.length).toEqual(1);
@@ -66,6 +69,7 @@ describe('createPagesWithData', () => {
               program_documents: null,
               external_program_website: null,
               branding: {},
+              contact_email: null,
             },
             {
               id: '0de66c11-6c9a-538b-aeb6-767f0013c96d',
@@ -77,6 +81,7 @@ describe('createPagesWithData', () => {
               program_documents: null,
               external_program_website: null,
               branding: {},
+              contact_email: 'hi@testorg.com',
             },
           ],
         },
@@ -127,6 +132,7 @@ describe('createPagesWithData', () => {
               program_documents: null,
               external_program_website: null,
               branding: {},
+              contact_email: null,
             },
             {
               id: '0de66c11-6c9a-538b-aeb6-767f0013c96a',
@@ -138,6 +144,7 @@ describe('createPagesWithData', () => {
               program_documents: null,
               external_program_website: null,
               branding: {},
+              contact_email: null,
             },
           ],
         },
@@ -195,6 +202,7 @@ describe('createPagesWithData', () => {
               program_documents: null,
               external_program_website: null,
               branding: {},
+              contact_email: null,
             },
             {
               id: '0de66c11-6c9a-538b-aeb6-767f0013c96a',
@@ -206,6 +214,7 @@ describe('createPagesWithData', () => {
               program_documents: null,
               external_program_website: null,
               branding: {},
+              contact_email: null,
             },
           ],
         },

--- a/src/components/enterprise/dashboard/sidebar/DashboardSidebar.jsx
+++ b/src/components/enterprise/dashboard/sidebar/DashboardSidebar.jsx
@@ -32,11 +32,12 @@ class DashboardSidebar extends React.Component {
     ));
   }
 
-  renderLearningCoordinatorHelpText(enterpriseName, enterpriseEmail) {
+  renderLearningCoordinatorHelpText() {
+    const { pageContext: { enterpriseName, enterpriseEmail } } = this.context;
     if (enterpriseEmail) {
       return (
         <a href={`mailto:${enterpriseEmail}`}>
-          Contact your {enterpriseName} learning coordinator
+          contact your {enterpriseName} learning coordinator
         </a>
       );
     }
@@ -44,7 +45,7 @@ class DashboardSidebar extends React.Component {
   }
 
   render() {
-    const { pageContext: { enterpriseName, enterpriseEmail } } = this.context;
+    const { pageContext: { enterpriseName } } = this.context;
     const {
       offers,
       isLoading,
@@ -53,7 +54,9 @@ class DashboardSidebar extends React.Component {
     return (
       <>
         {isLoading && (
-          <LoadingSpinner screenReaderText={`loading learning benefits for ${enterpriseName}`} />
+          <div className="mb-5">
+            <LoadingSpinner screenReaderText={`loading learning benefits for ${enterpriseName}`} />
+          </div>
         )}
         {hasOffers && (
           <SidebarBlock title={`Learning Benefits from ${enterpriseName}`} className="mb-5">
@@ -71,7 +74,7 @@ class DashboardSidebar extends React.Component {
             <p>
               To request more benefits or specific courses,
               {' '}
-              {this.renderLearningCoordinatorHelpText(enterpriseName, enterpriseEmail)}.
+              {this.renderLearningCoordinatorHelpText()}.
             </p>
           </div>
         </SidebarBlock>


### PR DESCRIPTION
This PR primarily includes `contact_email` in our GraphQL query and adds `contact_email` to the GraphQL schema (so that the query doesn't break the build if `contact_email` is empty, as will be the case for program pages).

It also adds some bottom margin on the loading spinner for offers in the sidebar so there's some space between the loading spinner and the "Need help?" section.