### PR TITLE
Clean up the title/settings button UI on course cards

### DIFF
--- a/src/components/common/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/common/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -144,7 +144,7 @@ class BaseCourseCard extends Component {
   renderSettingsDropdown = (menuItems) => {
     if (menuItems && menuItems.length > 0) {
       return (
-        <div className="col text-right">
+        <div className="flex-grow-0">
           <Dropdown>
             <Dropdown.Button className="btn-outline-secondary">
               <FontAwesomeIcon icon={faCog} />
@@ -261,7 +261,6 @@ class BaseCourseCard extends Component {
       hasViewCertificateLink,
     } = this.props;
     const dropdownMenuItems = this.getDropdownMenuItems();
-    const shouldDisplaySettingsDropdown = dropdownMenuItems.length > 0;
     return (
       <div
         className={classNames(
@@ -269,16 +268,8 @@ class BaseCourseCard extends Component {
           { 'is-micromasters': !!microMastersTitle },
         )}
       >
-        <div className="row no-gutters">
-          <div
-            className={classNames(
-              'mb-3',
-              {
-                'col-6 col-lg-8': shouldDisplaySettingsDropdown,
-                col: !shouldDisplaySettingsDropdown,
-              },
-            )}
-          >
+        <div className="d-flex">
+          <div className="flex-grow-1 mr-4 mb-3">
             {this.renderMicroMastersTitle()}
             <h4 className="course-title mb-1">
               <a href={linkToCourse}>{title}</a>

--- a/src/components/common/course-enrollments/course-cards/styles/CourseCard.scss
+++ b/src/components/common/course-enrollments/course-cards/styles/CourseCard.scss
@@ -62,7 +62,7 @@
     background-color: $white;
   }
 
-  @include media-breakpoint-down(sm) {
+  @include media-breakpoint-down(xs) {
     .btn-xs-block {
       width: 100%;
     }

--- a/src/components/common/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
+++ b/src/components/common/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
@@ -28,6 +28,7 @@ describe('<BaseCourseCard />', () => {
         <Provider store={store}>
           <LayoutContext.Provider value={{ pageContext }}>
             <BaseCourseCard
+              type="completed"
               title="edX Demonstration Course"
               linkToCourse="https://edx.org"
               courseRunId="my+course+key"


### PR DESCRIPTION
This PR removes the Bootstrap columns that controlled the positioning of the course title and settings dropdown in favor of a wrapper `div` that has the `.d-flex` (`display: flex`). 

With the help of the `.flex-grow-1` and `.flex-grow-0` classes, the settings dropdown `div` will always have the width of its children whereas the course title `div` will expand the remainder of the course card that the settings dropdown does not take up.

This allows the settings dropdown button to render nicely at the top right of course cards while letting the course title fill as much space as it needs. This holds true at all screen widths.