### PR TITLE
App-wide configurations for enterprise and masters

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,6 @@
 BASE_URL='localhost:8734'
-ENTERPRISE_CATALOG_MFE_URL=''
+ENTERPRISE_CATALOG_MFE_URL='http://example.com'
+ORDERS_MFE_URL='http://localhost:1996'
 LMS_BASE_URL='http://localhost:18000'
 ECOMMERCE_BASE_URL='http://localhost:18130'
 LOGIN_URL='http://localhost:18000/login'

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -40,6 +40,7 @@ module.exports = {
         whitelist: [
           'BASE_URL',
           'ENTERPRISE_CATALOG_MFE_URL',
+          'ORDERS_MFE_URL',
           'LMS_BASE_URL',
           'ECOMMERCE_BASE_URL',
           'LOGIN_URL',

--- a/src/components/common/app-context/AppContext.jsx
+++ b/src/components/common/app-context/AppContext.jsx
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+// eslint-disable-next-line import/prefer-default-export
+export const AppContext = createContext();

--- a/src/components/common/app-context/index.js
+++ b/src/components/common/app-context/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { AppContext } from './AppContext';

--- a/src/components/common/course-enrollments/CourseEnrollments.jsx
+++ b/src/components/common/course-enrollments/CourseEnrollments.jsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import MediaQuery from 'react-responsive';
 import { breakpoints, StatusAlert } from '@edx/paragon';
 
-import { LayoutContext } from '../layout';
+import { AppContext } from '../app-context';
 import { LoadingSpinner } from '../loading-spinner';
 import CourseSection from './CourseSection';
 import {
@@ -19,21 +19,20 @@ import * as selectors from './data/selectors';
 import * as actions from './data/actions';
 
 export class CourseEnrollments extends Component {
-  static contextType = LayoutContext;
+  static contextType = AppContext;
 
   componentDidMount() {
     const {
       pageContext: {
-        pageType,
         programUUID, // for Masters, empty for Enterprise
         enterpriseUUID, // for Enterprise, empty for Masters
       },
     } = this.context;
     const { fetchCourseEnrollments } = this.props;
-    const options = { pageType };
-    if (pageType === 'pages.ProgramPage') {
+    const options = {};
+    if (programUUID) {
       options.programUUID = programUUID;
-    } else if (pageType === 'pages.EnterprisePage') {
+    } else if (enterpriseUUID) {
       options.enterpriseUUID = enterpriseUUID;
     }
     fetchCourseEnrollments(options);

--- a/src/components/common/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/common/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -8,13 +8,13 @@ import { faCog } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Dropdown } from '@edx/paragon';
 
-import { LayoutContext } from '../../layout';
+import { AppContext } from '../../app-context';
 import { EmailSettingsModal } from './email-settings';
 
 import './styles/CourseCard.scss';
 
 class BaseCourseCard extends Component {
-  static contextType = LayoutContext;
+  static contextType = AppContext;
 
   state = {
     modals: {
@@ -187,8 +187,8 @@ class BaseCourseCard extends Component {
   };
 
   renderSponsoredByEnterpriseMessage = () => {
-    const { pageContext: { pageType, enterpriseName } } = this.context;
-    if (pageType === 'pages.EnterprisePage') {
+    const { pageContext: { enterpriseName } } = this.context;
+    if (enterpriseName) {
       return <small>Sponsored by {enterpriseName}.</small>;
     }
     return null;

--- a/src/components/common/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx
+++ b/src/components/common/course-enrollments/course-cards/mark-complete-modal/MarkCompleteModal.jsx
@@ -4,7 +4,7 @@ import { Modal, StatefulButton } from '@edx/paragon';
 
 import ModalBody from './ModalBody';
 import { markCourseAsCompleteRequest } from './data/service';
-import { LayoutContext } from '../../../layout';
+import { AppContext } from '../../../app-context';
 import { camelCaseObject } from '../../../../../common/utils';
 
 export const MarkCompleteModalContext = createContext();
@@ -23,7 +23,7 @@ const MarkCompleteModal = ({
   onSuccess,
   onClose,
 }) => {
-  const { pageContext: { enterpriseUUID } } = useContext(LayoutContext);
+  const { pageContext: { enterpriseUUID } } = useContext(AppContext);
   const [
     { confirmButtonState, confirmError, confirmSuccessful },
     setState,

--- a/src/components/common/course-enrollments/course-cards/mark-complete-modal/tests/MarkCompleteModal.test.jsx
+++ b/src/components/common/course-enrollments/course-cards/mark-complete-modal/tests/MarkCompleteModal.test.jsx
@@ -2,22 +2,26 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 
-import { LayoutContext } from '../../../../layout';
+import { AppContext } from '../../../../app-context';
 import MarkCompleteModal from '../MarkCompleteModal';
 import * as service from '../data/service';
 
 jest.mock('../data/service');
 
-const initialProps = {
-  isOpen: true,
-  onSuccess: jest.fn(),
-  onClose: jest.fn(),
-  courseId: 'course-v1:my-test-course',
-  courseTitle: 'edX Demonstration Course',
-  courseLink: 'https://edx.org',
-};
-
 describe('<MarkCompleteModal />', () => {
+  const initialProps = {
+    isOpen: true,
+    onSuccess: jest.fn(),
+    onClose: jest.fn(),
+    courseId: 'course-v1:my-test-course',
+    courseTitle: 'edX Demonstration Course',
+    courseLink: 'https://edx.org',
+  };
+
+  const pageContext = {
+    enterpriseUUID: 'example-enterprise-uuid',
+  };
+
   it('handles confirm click with success', () => {
     service.markCourseAsCompleteRequest = jest.fn()
       .mockImplementation(() => Promise.resolve({
@@ -25,16 +29,12 @@ describe('<MarkCompleteModal />', () => {
           course_run_status: 'completed',
         },
       }));
-    const pageContext = {
-      pageType: 'pages.EnterprisePage',
-      enterpriseUUID: 'example-enterprise-uuid',
-    };
     const wrapper = mount((
-      <LayoutContext.Provider value={{ pageContext }}>
+      <AppContext.Provider value={{ pageContext }}>
         <MarkCompleteModal
           {...initialProps}
         />
-      </LayoutContext.Provider>
+      </AppContext.Provider>
     ));
     wrapper.find('.confirm-mark-complete-btn').hostNodes().simulate('click');
     expect(service.markCourseAsCompleteRequest).toBeCalledWith({
@@ -48,16 +48,12 @@ describe('<MarkCompleteModal />', () => {
   it('handles confirm click with error', async () => {
     service.markCourseAsCompleteRequest = jest.fn()
       .mockImplementation(() => Promise.reject(new Error('test error')));
-    const pageContext = {
-      pageType: 'pages.EnterprisePage',
-      enterpriseUUID: 'example-enterprise-uuid',
-    };
     const wrapper = mount((
-      <LayoutContext.Provider value={{ pageContext }}>
+      <AppContext.Provider value={{ pageContext }}>
         <MarkCompleteModal
           {...initialProps}
         />
-      </LayoutContext.Provider>
+      </AppContext.Provider>
     ));
     await act(async () => {
       wrapper.find('.confirm-mark-complete-btn').hostNodes().simulate('click');
@@ -72,17 +68,13 @@ describe('<MarkCompleteModal />', () => {
 
   it('handles close modal', () => {
     const mockOnClose = jest.fn();
-    const pageContext = {
-      pageType: 'pages.EnterprisePage',
-      enterpriseUUID: 'example-enterprise-uuid',
-    };
     const wrapper = mount((
-      <LayoutContext.Provider value={{ pageContext }}>
+      <AppContext.Provider value={{ pageContext }}>
         <MarkCompleteModal
           {...initialProps}
           onClose={mockOnClose}
         />
-      </LayoutContext.Provider>
+      </AppContext.Provider>
     ));
     act(() => {
       wrapper.find('.modal-footer button.js-close-modal-on-click').hostNodes().simulate('click');

--- a/src/components/common/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
+++ b/src/components/common/course-enrollments/course-cards/tests/BaseCourseCard.test.jsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import * as analytics from '@edx/frontend-analytics';
 
-import { LayoutContext } from '../../../layout';
+import { AppContext } from '../../../app-context';
 import BaseCourseCard from '../BaseCourseCard';
 
 const mockStore = configureMockStore([thunk]);
@@ -22,11 +22,11 @@ describe('<BaseCourseCard />', () => {
 
     beforeEach(() => {
       const pageContext = {
-        pageType: 'pages.EnterprisePage',
+        enterpriseName: 'test-enterprise-name',
       };
       wrapper = mount((
         <Provider store={store}>
-          <LayoutContext.Provider value={{ pageContext }}>
+          <AppContext.Provider value={{ pageContext }}>
             <BaseCourseCard
               type="completed"
               title="edX Demonstration Course"
@@ -34,7 +34,7 @@ describe('<BaseCourseCard />', () => {
               courseRunId="my+course+key"
               hasEmailsEnabled
             />
-          </LayoutContext.Provider>
+          </AppContext.Provider>
         </Provider>
       ));
       // open email settings modal

--- a/src/components/common/course-enrollments/data/actions.js
+++ b/src/components/common/course-enrollments/data/actions.js
@@ -57,22 +57,25 @@ export const fetchCourseEnrollments = options => (
   (dispatch) => {
     dispatch(fetchCourseEnrollmentsRequest());
     let serviceMethod;
-    if (options.pageType === 'pages.EnterprisePage') {
+    if (options.enterpriseUUID) {
       serviceMethod = () => service.fetchEnterpriseCourseEnrollments(options.enterpriseUUID);
-    } else {
+    } else if (options.programUUID) {
       serviceMethod = () => service.fetchProgramCourseEnrollments(options.programUUID);
     }
-    return serviceMethod()
-      .then((response) => {
-        const transformedResponse = transformCourseEnrollmentsResponse({
-          responseData: response.data,
-          options,
+    if (serviceMethod) {
+      return serviceMethod()
+        .then((response) => {
+          const transformedResponse = transformCourseEnrollmentsResponse({
+            responseData: response.data,
+            options,
+          });
+          dispatch(fetchCourseEnrollmentsSuccess(transformedResponse));
+        })
+        .catch((error) => {
+          dispatch(fetchCourseEnrollmentsFailure(error));
         });
-        dispatch(fetchCourseEnrollmentsSuccess(transformedResponse));
-      })
-      .catch((error) => {
-        dispatch(fetchCourseEnrollmentsFailure(error));
-      });
+    }
+    return undefined;
   }
 );
 

--- a/src/components/common/course-enrollments/tests/CourseEnrollments.test.jsx
+++ b/src/components/common/course-enrollments/tests/CourseEnrollments.test.jsx
@@ -8,7 +8,7 @@ import { breakpoints } from '@edx/paragon';
 
 import '../../../../__mocks__/reactResponsive.mock';
 
-import { LayoutContext } from '../../../common/layout';
+import { AppContext } from '../../../common/app-context';
 import { CourseEnrollments } from '../CourseEnrollments';
 
 const mockStore = configureMockStore([thunk]);
@@ -31,15 +31,16 @@ describe('<CourseEnrollments />', () => {
     isMarkCourseCompleteSuccess: false,
     modifyIsMarkCourseCompleteSuccess: mockModifyIsMarkCourseCompleteSuccess,
   };
+
   describe('renders course enrollments correctly', () => {
     it('with no course enrollments', () => {
       const pageContext = {
-        pageType: 'pages.EnterprisePage',
+        enterpriseUUID: 'test-enterprise-uuid',
       };
       const wrapper = mount((
-        <LayoutContext.Provider value={{ pageContext }}>
+        <AppContext.Provider value={{ pageContext }}>
           <CourseEnrollments {...initialProps} />
-        </LayoutContext.Provider>
+        </AppContext.Provider>
       ));
       expect(wrapper.exists('.course-section')).toBeFalsy();
     });
@@ -72,7 +73,6 @@ describe('<CourseEnrollments />', () => {
         completed: [sampleCourseRun],
       };
       const pageContext = {
-        pageType: 'pages.ProgramPage',
         programUUID: 'test-program-uuid',
       };
       const store = mockStore({
@@ -87,12 +87,12 @@ describe('<CourseEnrollments />', () => {
       });
       const wrapper = mount((
         <Provider store={store}>
-          <LayoutContext.Provider value={{ pageContext }}>
+          <AppContext.Provider value={{ pageContext }}>
             <CourseEnrollments
               {...initialProps}
               courseRuns={courseRuns}
             />
-          </LayoutContext.Provider>
+          </AppContext.Provider>
         </Provider>
       ));
 
@@ -104,16 +104,16 @@ describe('<CourseEnrollments />', () => {
 
     it('with error', () => {
       const pageContext = {
-        pageType: 'pages.EnterprisePage',
+        enterpriseUUID: 'test-enterprise-uuid',
       };
       const tree = renderer
         .create((
-          <LayoutContext.Provider value={{ pageContext }}>
+          <AppContext.Provider value={{ pageContext }}>
             <CourseEnrollments
               {...initialProps}
               error={new Error('Network Error')}
             />
-          </LayoutContext.Provider>
+          </AppContext.Provider>
         ))
         .toJSON();
       expect(tree).toMatchSnapshot();
@@ -121,16 +121,16 @@ describe('<CourseEnrollments />', () => {
 
     it('with loading', () => {
       const pageContext = {
-        pageType: 'pages.EnterprisePage',
+        enterpriseUUID: 'test-enterprise-uuid',
       };
       const tree = renderer
         .create((
-          <LayoutContext.Provider value={{ pageContext }}>
+          <AppContext.Provider value={{ pageContext }}>
             <CourseEnrollments
               {...initialProps}
               isLoading
             />
-          </LayoutContext.Provider>
+          </AppContext.Provider>
         ))
         .toJSON();
       expect(tree).toMatchSnapshot();
@@ -138,16 +138,16 @@ describe('<CourseEnrollments />', () => {
 
     it('with mark course as complete success status alert', () => {
       const pageContext = {
-        pageType: 'pages.EnterpsrisePage',
+        enterpriseUUID: 'test-enterprise-uuid',
       };
       const tree = renderer
         .create((
-          <LayoutContext.Provider value={{ pageContext }}>
+          <AppContext.Provider value={{ pageContext }}>
             <CourseEnrollments
               {...initialProps}
               isMarkCourseCompleteSuccess
             />
-          </LayoutContext.Provider>
+          </AppContext.Provider>
         ))
         .toJSON();
       expect(tree).toMatchSnapshot();
@@ -160,12 +160,12 @@ describe('<CourseEnrollments />', () => {
     it('is not shown at screen widths greater than or equal to large breakpoint', () => {
       global.innerWidth = breakpoints.large.minWidth;
       const pageContext = {
-        pageType: 'pages.EnterprisePage',
+        enterpriseUUID: 'test-enterprise-uuid',
       };
       wrapper = mount((
-        <LayoutContext.Provider value={{ pageContext }}>
+        <AppContext.Provider value={{ pageContext }}>
           <CourseEnrollments {...initialProps} />
-        </LayoutContext.Provider>
+        </AppContext.Provider>
       ));
       expect(wrapper.find('.sidebar-example').exists()).toBeFalsy();
     });
@@ -173,12 +173,12 @@ describe('<CourseEnrollments />', () => {
     it('is shown at screen widths less than large breakpoint', () => {
       global.innerWidth = breakpoints.small.minWidth;
       const pageContext = {
-        pageType: 'pages.EnterprisePage',
+        enterpriseUUID: 'test-enterprise-uuid',
       };
       wrapper = mount((
-        <LayoutContext.Provider value={{ pageContext }}>
+        <AppContext.Provider value={{ pageContext }}>
           <CourseEnrollments {...initialProps} />
-        </LayoutContext.Provider>
+        </AppContext.Provider>
       ));
       expect(wrapper.find('.sidebar-example').exists()).toBeTruthy();
     });
@@ -192,18 +192,14 @@ describe('<CourseEnrollments />', () => {
 
     it('for program page', () => {
       const programUUID = 'test-program-uuid';
-      const pageContext = {
-        pageType: 'pages.ProgramPage',
-        programUUID,
-      };
+      const pageContext = { programUUID };
       mount((
-        <LayoutContext.Provider value={{ pageContext }}>
+        <AppContext.Provider value={{ pageContext }}>
           <CourseEnrollments {...initialProps} />
-        </LayoutContext.Provider>
+        </AppContext.Provider>
       ));
       expect(mockFetchCourseEnrollments.mock.calls.length).toEqual(1);
       expect(mockFetchCourseEnrollments).toBeCalledWith({
-        pageType: 'pages.ProgramPage',
         programUUID,
       });
     });
@@ -211,17 +207,15 @@ describe('<CourseEnrollments />', () => {
     it('for enterprise page', () => {
       const enterpriseUUID = 'test-enterprise-uuid';
       const pageContext = {
-        pageType: 'pages.EnterprisePage',
         enterpriseUUID,
       };
       mount((
-        <LayoutContext.Provider value={{ pageContext }}>
+        <AppContext.Provider value={{ pageContext }}>
           <CourseEnrollments {...initialProps} />
-        </LayoutContext.Provider>
+        </AppContext.Provider>
       ));
       expect(mockFetchCourseEnrollments.mock.calls.length).toEqual(1);
       expect(mockFetchCourseEnrollments).toBeCalledWith({
-        pageType: 'pages.EnterprisePage',
         enterpriseUUID,
       });
     });
@@ -229,15 +223,15 @@ describe('<CourseEnrollments />', () => {
 
   it('properly closes mark course as complete success status alert', () => {
     const pageContext = {
-      pageType: 'pages.EnterpsrisePage',
+      enterpriseUUID: 'test-enterprise-uuid',
     };
     const wrapper = mount((
-      <LayoutContext.Provider value={{ pageContext }}>
+      <AppContext.Provider value={{ pageContext }}>
         <CourseEnrollments
           {...initialProps}
           isMarkCourseCompleteSuccess
         />
-      </LayoutContext.Provider>
+      </AppContext.Provider>
     ));
     wrapper.find('.alert .btn.close').simulate('click');
     expect(mockModifyIsMarkCourseCompleteSuccess).toBeCalledTimes(1);

--- a/src/components/common/hero/Hero.jsx
+++ b/src/components/common/hero/Hero.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
-import { LayoutContext } from '../layout';
+import { AppContext } from '../app-context';
 
 import './styles/Hero.scss';
 
@@ -10,7 +10,7 @@ const Hero = (props) => {
     pageContext: {
       pageBranding,
     },
-  } = useContext(LayoutContext);
+  } = useContext(AppContext);
   const { title } = props;
 
   return (

--- a/src/components/common/hero/tests/Hero.test.jsx
+++ b/src/components/common/hero/tests/Hero.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import { LayoutContext } from '../../layout';
+import { AppContext } from '../../app-context';
 import Hero from '../Hero';
 
 describe('<Hero />', () => {
@@ -20,9 +20,9 @@ describe('<Hero />', () => {
 
     const tree = renderer
       .create((
-        <LayoutContext.Provider value={{ pageContext }}>
+        <AppContext.Provider value={{ pageContext }}>
           <Hero title="Example Title" />
-        </LayoutContext.Provider>
+        </AppContext.Provider>
       ))
       .toJSON();
     expect(tree).toMatchSnapshot();

--- a/src/components/common/layout/Layout.jsx
+++ b/src/components/common/layout/Layout.jsx
@@ -6,52 +6,28 @@ import SiteHeader from '@edx/frontend-component-site-header';
 import SiteFooter from '@edx/frontend-component-footer';
 import { connect } from 'react-redux';
 
+import { AppContext } from '../app-context';
+
 import EdXLogo from '../../../images/edx-logo.svg';
 
 import './styles/Layout.scss';
 
-const LayoutContext = React.createContext();
-
 class Layout extends Component {
+  static contextType = AppContext;
+
   getUserMenuItems = () => {
-    const { pageContext: { pageType }, username } = this.props;
-    const menuItems = [
-      {
-        type: 'item',
-        href: process.env.LMS_BASE_URL,
-        content: 'Dashboard',
-      },
-      {
-        type: 'item',
-        href: `${process.env.LMS_BASE_URL}/u/${username}`,
-        content: 'Profile',
-      },
-      {
-        type: 'item',
-        href: `${process.env.LMS_BASE_URL}/account/settings`,
-        content: 'Account Settings',
-      },
-      {
-        type: 'item',
-        href: process.env.LOGOUT_URL,
-        content: 'Sign out',
-      },
-    ];
+    const { header: { userMenu } } = this.context;
+    return userMenu || [];
+  };
 
-    if (pageType !== 'pages.EnterprisePage') {
-      menuItems.splice(1, 0, {
-        type: 'item',
-        href: '/',
-        content: 'My Masters Degree',
-      });
-    }
-
-    return menuItems;
+  getMainMenuItems = () => {
+    const { header: { mainMenu } } = this.context;
+    return mainMenu || [];
   };
 
   render() {
     const {
-      siteUrl, siteName, username, avatar, pageContext, children, headerLogo, footerLogo,
+      siteUrl, siteName, username, avatar, children, headerLogo, footerLogo,
     } = this.props;
     return (
       <IntlProvider locale="en">
@@ -64,6 +40,7 @@ class Layout extends Component {
             loggedIn={!!username}
             username={username}
             avatar={avatar}
+            mainMenu={this.getMainMenuItems()}
             userMenu={this.getUserMenuItems()}
             loggedOutItems={[
               { type: 'item', href: '#', content: 'Login' },
@@ -71,11 +48,9 @@ class Layout extends Component {
             ]}
             skipNavId="content"
           />
-          <LayoutContext.Provider value={{ pageContext }}>
-            <main id="content">
-              {children}
-            </main>
-          </LayoutContext.Provider>
+          <main id="content">
+            {children}
+          </main>
           <SiteFooter
             siteName={siteName}
             siteLogo={footerLogo || EdXLogo}
@@ -102,7 +77,6 @@ class Layout extends Component {
 }
 
 Layout.defaultProps = {
-  pageContext: {},
   avatar: null,
   children: [],
   siteName: 'edX',
@@ -113,9 +87,6 @@ Layout.defaultProps = {
 };
 
 Layout.propTypes = {
-  pageContext: PropTypes.shape({
-    pageType: PropTypes.string,
-  }),
   avatar: PropTypes.string,
   children: PropTypes.node,
   siteName: PropTypes.string,
@@ -129,7 +100,5 @@ const ConnectedLayout = connect(state => ({
   avatar: state.userAccount.profileImage.imageUrlMedium,
   username: state.authentication.username,
 }))(Layout);
-
-export { LayoutContext };
 
 export default ConnectedLayout;

--- a/src/components/common/layout/index.js
+++ b/src/components/common/layout/index.js
@@ -1,4 +1,4 @@
-export { default as Layout, LayoutContext } from './Layout';
+export { default as Layout } from './Layout';
 export { default as MainContent } from './MainContent';
 export { default as Sidebar } from './Sidebar';
 export { default as SidebarBlock } from './SidebarBlock';

--- a/src/components/enterprise/dashboard/DashboardPage.jsx
+++ b/src/components/enterprise/dashboard/DashboardPage.jsx
@@ -10,32 +10,36 @@ import { Hero } from '../../common/hero';
 import { DashboardMainContent } from './main-content';
 import { DashboardSidebar } from './sidebar';
 
+import { EnterprisePage } from '../enterprise-page';
+
 const DashboardPage = (props) => {
   const { pageContext } = props;
   const { enterpriseName } = pageContext;
   return (
-    <Layout
-      pageContext={pageContext}
-      headerLogo={pageContext.pageBranding.organization_logo.url}
-      footerLogo="https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png"
-    >
-      <Helmet title={enterpriseName} />
-      <Hero title={enterpriseName} />
-      <div className="container py-5">
-        <div className="row">
-          <MainContent>
-            <DashboardMainContent />
-          </MainContent>
-          <MediaQuery minWidth={breakpoints.large.minWidth}>
-            {matches => matches && (
-              <Sidebar>
-                <DashboardSidebar />
-              </Sidebar>
-            )}
-          </MediaQuery>
+    <EnterprisePage pageContext={pageContext}>
+      <Layout
+        pageContext={pageContext}
+        headerLogo={pageContext.pageBranding.organization_logo.url}
+        footerLogo="https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png"
+      >
+        <Helmet title={enterpriseName} />
+        <Hero title={enterpriseName} />
+        <div className="container py-5">
+          <div className="row">
+            <MainContent>
+              <DashboardMainContent />
+            </MainContent>
+            <MediaQuery minWidth={breakpoints.large.minWidth}>
+              {matches => matches && (
+                <Sidebar>
+                  <DashboardSidebar />
+                </Sidebar>
+              )}
+            </MediaQuery>
+          </div>
         </div>
-      </div>
-    </Layout>
+      </Layout>
+    </EnterprisePage>
   );
 };
 

--- a/src/components/enterprise/dashboard/DashboardPage.jsx
+++ b/src/components/enterprise/dashboard/DashboardPage.jsx
@@ -18,7 +18,6 @@ const DashboardPage = (props) => {
   return (
     <EnterprisePage pageContext={pageContext}>
       <Layout
-        pageContext={pageContext}
         headerLogo={pageContext.pageBranding.organization_logo.url}
         footerLogo="https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png"
       >

--- a/src/components/enterprise/dashboard/main-content/DashboardMainContent.jsx
+++ b/src/components/enterprise/dashboard/main-content/DashboardMainContent.jsx
@@ -1,11 +1,11 @@
 import React, { useContext } from 'react';
 
-import { LayoutContext } from '../../../common/layout';
+import { AppContext } from '../../../common/app-context';
 import { CourseEnrollments } from '../../../common/course-enrollments';
 import { DashboardSidebar } from '../sidebar';
 
 const DashboardMainContent = () => {
-  const { pageContext: { enterpriseName } } = useContext(LayoutContext);
+  const { pageContext: { enterpriseName } } = useContext(AppContext);
   return (
     <CourseEnrollments sidebarComponent={<DashboardSidebar />}>
       <h3>Browse courses</h3>

--- a/src/components/enterprise/dashboard/sidebar/DashboardSidebar.jsx
+++ b/src/components/enterprise/dashboard/sidebar/DashboardSidebar.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import { LayoutContext, SidebarBlock } from '../../../common/layout';
+import { AppContext } from '../../../common/app-context';
+import { SidebarBlock } from '../../../common/layout';
 import { LoadingSpinner } from '../../../common/loading-spinner';
 import { fetchOffers, Offer } from './offers';
 
 class DashboardSidebar extends React.Component {
-  static contextType = LayoutContext;
+  static contextType = AppContext;
 
   componentDidMount() {
     this.props.fetchOffers();

--- a/src/components/enterprise/enterprise-page/EnterprisePage.jsx
+++ b/src/components/enterprise/enterprise-page/EnterprisePage.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { AppContext } from '../../common/app-context';
+
+const EnterprisePage = ({
+  children,
+  pageContext,
+  username,
+}) => (
+  <AppContext.Provider
+    value={{
+      header: {
+        mainMenu: [
+          {
+            type: 'item',
+            href: process.env.ENTERPRISE_CATALOG_MFE_URL,
+            content: 'Catalog',
+          },
+          {
+            type: 'item',
+            href: 'https://support.edx.org/hc/en-us',
+            content: 'Help',
+          },
+        ],
+        userMenu: [
+          {
+            type: 'item',
+            href: process.env.LMS_BASE_URL,
+            content: 'Dashboard',
+          },
+          {
+            type: 'item',
+            href: `${process.env.LMS_BASE_URL}/u/${username}`,
+            content: 'My Profile',
+          },
+          {
+            type: 'item',
+            href: `${process.env.LMS_BASE_URL}/account/settings`,
+            content: 'Account Settings',
+          },
+          {
+            type: 'item',
+            href: `${process.env.ORDERS_MFE_URL}/orders`,
+            content: 'Order History',
+          },
+          {
+            type: 'item',
+            href: 'https://support.edx.org/hc/en-us',
+            content: 'Help',
+          },
+          {
+            type: 'item',
+            href: process.env.LOGOUT_URL,
+            content: 'Sign Out',
+          },
+        ],
+      },
+      courseCards: {
+        'in-progress': {
+          settingsMenu: {
+            hasMarkComplete: true,
+          },
+        },
+      },
+      pageContext,
+    }}
+  >
+    {children}
+  </AppContext.Provider>
+);
+
+EnterprisePage.propTypes = {
+  children: PropTypes.element.isRequired,
+  pageContext: PropTypes.shape({
+    pageType: PropTypes.string,
+    pageBranding: PropTypes.shape({}),
+    enterpriseName: PropTypes.string,
+    enterpriseUUID: PropTypes.string,
+    enterpriseEmail: PropTypes.string,
+  }).isRequired,
+  username: PropTypes.string.isRequired,
+};
+
+const mapStateToProps = state => ({
+  username: state.authentication.username,
+});
+
+export default connect(mapStateToProps)(EnterprisePage);
+

--- a/src/components/enterprise/enterprise-page/index.js
+++ b/src/components/enterprise/enterprise-page/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as EnterprisePage } from './EnterprisePage';

--- a/src/components/masters/masters-page/MastersPage.jsx
+++ b/src/components/masters/masters-page/MastersPage.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { AppContext } from '../../common/app-context';
+
+const MastersPage = ({
+  children,
+  pageContext,
+  username,
+}) => (
+  <AppContext.Provider
+    value={{
+      header: {
+        userMenu: [
+          {
+            type: 'item',
+            href: process.env.LMS_BASE_URL,
+            content: 'Dashboard',
+          },
+          {
+            type: 'item',
+            href: '/',
+            content: 'My Masters Degree',
+          },
+          {
+            type: 'item',
+            href: `${process.env.LMS_BASE_URL}/u/${username}`,
+            content: 'My Profile',
+          },
+          {
+            type: 'item',
+            href: `${process.env.LMS_BASE_URL}/account/settings`,
+            content: 'Account Settings',
+          },
+          {
+            type: 'item',
+            href: process.env.LOGOUT_URL,
+            content: 'Sign Out',
+          },
+        ],
+      },
+      pageContext,
+    }}
+  >
+    {children}
+  </AppContext.Provider>
+);
+
+MastersPage.propTypes = {
+  children: PropTypes.element.isRequired,
+  pageContext: PropTypes.shape({}).isRequired,
+  username: PropTypes.string.isRequired,
+};
+
+const mapStateToProps = state => ({
+  username: state.authentication.username,
+});
+
+export default connect(mapStateToProps)(MastersPage);
+

--- a/src/components/masters/masters-page/index.js
+++ b/src/components/masters/masters-page/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as MastersPage } from './MastersPage';

--- a/src/components/masters/program/ProgramPage.jsx
+++ b/src/components/masters/program/ProgramPage.jsx
@@ -12,6 +12,7 @@ import { Hero } from '../../common/hero';
 import { withAuthentication } from '../../common/with-authentication';
 import { Layout, MainContent, Sidebar } from '../../common/layout';
 import { LoadingSpinner } from '../../common/loading-spinner';
+import { MastersPage } from '../masters-page';
 import { ProgramMainContent } from './main-content';
 import { ProgramSidebar } from './sidebar';
 
@@ -80,40 +81,42 @@ class ProgramPage extends Component {
     const { programName } = pageContext;
 
     return (
-      <Layout pageContext={pageContext}>
-        {isLoading ? (
-          <div className="container py-5">
-            <div className="col">
-              <LoadingSpinner screenReaderText="loading program enrollments" />
+      <MastersPage pageContext={pageContext}>
+        <Layout>
+          {isLoading ? (
+            <div className="container py-5">
+              <div className="col">
+                <LoadingSpinner screenReaderText="loading program enrollments" />
+              </div>
             </div>
-          </div>
-        ) : (
-          <>
-            {hasProgramAccess ? (
-              <>
-                <Helmet title={programName} />
-                <Hero title={programName} />
-                <div className="container py-5">
-                  <div className="row">
-                    <MainContent>
-                      <ProgramMainContent />
-                    </MainContent>
-                    <MediaQuery minWidth={breakpoints.large.minWidth}>
-                      {matches => matches && (
-                        <Sidebar>
-                          <ProgramSidebar />
-                        </Sidebar>
-                      )}
-                    </MediaQuery>
+          ) : (
+            <>
+              {hasProgramAccess ? (
+                <>
+                  <Helmet title={programName} />
+                  <Hero title={programName} />
+                  <div className="container py-5">
+                    <div className="row">
+                      <MainContent>
+                        <ProgramMainContent />
+                      </MainContent>
+                      <MediaQuery minWidth={breakpoints.large.minWidth}>
+                        {matches => matches && (
+                          <Sidebar>
+                            <ProgramSidebar />
+                          </Sidebar>
+                        )}
+                      </MediaQuery>
+                    </div>
                   </div>
-                </div>
-              </>
-            ) : (
-              this.renderError()
-            )}
-          </>
-        )}
-      </Layout>
+                </>
+              ) : (
+                this.renderError()
+              )}
+            </>
+          )}
+        </Layout>
+      </MastersPage>
     );
   }
 }

--- a/src/components/masters/program/sidebar/ProgramSidebar.jsx
+++ b/src/components/masters/program/sidebar/ProgramSidebar.jsx
@@ -3,7 +3,8 @@ import { sendTrackEvent } from '@edx/frontend-analytics';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { LayoutContext, SidebarBlock } from '../../../common/layout';
+import { AppContext } from '../../../common/app-context';
+import { SidebarBlock } from '../../../common/layout';
 import Links from './Links';
 
 const ProgramSidebar = () => {
@@ -11,7 +12,7 @@ const ProgramSidebar = () => {
     pageContext: {
       programDocuments, externalProgramWebsite,
     },
-  } = useContext(LayoutContext);
+  } = useContext(AppContext);
 
   return (
     <>

--- a/src/components/masters/program/sidebar/tests/ProgramSidebar.test.jsx
+++ b/src/components/masters/program/sidebar/tests/ProgramSidebar.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import { LayoutContext } from '../../../../common/layout';
+import { AppContext } from '../../../../common/app-context';
 
 import ProgramSidebar from '../ProgramSidebar';
 
@@ -13,9 +13,9 @@ describe('<ProgramSidebar />', () => {
     };
     const tree = renderer
       .create((
-        <LayoutContext.Provider value={{ pageContext }}>
+        <AppContext.Provider value={{ pageContext }}>
           <ProgramSidebar />
-        </LayoutContext.Provider>
+        </AppContext.Provider>
       ))
       .toJSON();
     expect(tree).toMatchSnapshot();
@@ -44,9 +44,9 @@ describe('<ProgramSidebar />', () => {
       externalProgramWebsite: 'https://edx.org',
     };
     const tree = renderer.create((
-      <LayoutContext.Provider value={{ pageContext }}>
+      <AppContext.Provider value={{ pageContext }}>
         <ProgramSidebar />
-      </LayoutContext.Provider>
+      </AppContext.Provider>
     )).toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/src/components/masters/programs-list/ProgramListPage.jsx
+++ b/src/components/masters/programs-list/ProgramListPage.jsx
@@ -9,6 +9,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { withAuthentication } from '../../common/with-authentication';
 import { Layout } from '../../common/layout';
 import { LoadingSpinner } from '../../common/loading-spinner';
+import { MastersPage } from '../masters-page';
 
 import { fetchUserProgramEnrollments } from '../user-program-enrollments';
 
@@ -85,11 +86,11 @@ export class ProgramListPage extends Component {
   );
 
   render() {
-    const { isLoading, error } = this.props;
+    const { isLoading, error, pageContext } = this.props;
     const { validPrograms } = this.state;
 
     return (
-      <>
+      <MastersPage pageContext={pageContext}>
         {isLoading ? (
           <Layout>
             <div className="container my-4">
@@ -152,7 +153,7 @@ export class ProgramListPage extends Component {
             )}
           </>
         )}
-      </>
+      </MastersPage>
     );
   }
 }


### PR DESCRIPTION
My proposed solution for [ENT-2280](https://openedx.atlassian.net/browse/ENT-2280) involves some refactoring to add 3 new components: `AppContext`, `EnterprisePage`, and `MastersPage`. It also removes `LayoutContext` in favor of `AppContext`.

Now, `Layout` (and other components) pull from `AppContext` to get whatever configuration it needs. The value for `AppContext` is set in `EnterprisePage` and `MastersPage`. The value is meant to be an app-wide configuration, where you can pass in the `pageContext` as well as header menu items that should only apply for masters vs. enterprise, without needing to do any conditionals based on `pageType` (e.g., "pages.EnterprisePage").

This also tackles the TODO [noted here](https://github.com/edx/frontend-app-learner-portal/blob/c748b14ce06ef1c774c931440a2def0a72db048f/src/components/common/course-enrollments/course-cards/InProgressCourseCard.jsx#L53). Because this app-wide configuration could also include configurations/overrides for features, such as whether the "Mark as complete" button appears for enterprise.

Example value for `AppContext` (e.g., set in `EnterprisePage`):
```
{
  header: {
    mainMenu: [
      {
        type: 'item',
        href: process.env.ENTERPRISE_CATALOG_MFE_URL,
        content: 'Catalog',
      },
      {
        type: 'item',
        href: 'https://support.edx.org/hc/en-us',
        content: 'Help',
      },
    ],
    userMenu: [
      {
        type: 'item',
        href: process.env.LMS_BASE_URL,
        content: 'Dashboard',
      },
      {
        type: 'item',
        href: `${process.env.LMS_BASE_URL}/u/${username}`,
        content: 'My Profile',
      },
      // ...
    ],
  },
  courseCards: {
    'in-progress': {
      settingsMenu: {
        hasMarkComplete: true,
      },
    },
  },
  pageContext,
}
```
I feel like this sort of approach could make sense, but curious to hear any feedback. In situations like whether the "Mark as complete" button shows, we still have a conditional to see if `hasMarkComplete` exists & is true. But, at least, it's a conditional that isn't explicitly dependent on a `pageType`.