### PR TITLE
Sidebar offers moved behind "enterprise_offers" feature flag

### DIFF
--- a/src/common/features.js
+++ b/src/common/features.js
@@ -13,6 +13,8 @@
  *      the chosen name. Example: `isFeatureEnabled('move_to_completed')`.
  *   3. To see it in action, specify `?features=FEATURE_NAME` in the URL and refresh
  *      the page. Example: `?features=move_to_completed`.
+ *   4. To enable multiple feature flags at once, use a comma-separated list of features
+ *      in the query parameter. Example: `?features=move_to_completed,enterprise_offers`.
  */
 
 import qs from 'query-string';

--- a/src/components/common/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/common/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -274,9 +274,9 @@ class BaseCourseCard extends Component {
         <div className="d-flex">
           <div className="flex-grow-1 mr-4 mb-3">
             {this.renderMicroMastersTitle()}
-            <h4 className="course-title mb-1">
+            <h3 className="course-title mb-1">
               <a href={linkToCourse}>{title}</a>
-            </h4>
+            </h3>
             {this.renderOrganizationName()}
           </div>
           {this.renderSettingsDropdown(dropdownMenuItems)}

--- a/src/components/common/course-enrollments/course-cards/styles/CourseCard.scss
+++ b/src/components/common/course-enrollments/course-cards/styles/CourseCard.scss
@@ -37,6 +37,8 @@
   }
 
   .course-title > a {
+    @extend .h4;
+    @extend .m-0;
     @extend .text-dark;
     text-decoration: none;
   }

--- a/src/components/common/course-enrollments/styles/CourseSection.scss
+++ b/src/components/common/course-enrollments/styles/CourseSection.scss
@@ -1,6 +1,9 @@
 @import "~@edx/paragon/scss/edx/theme.scss";
 
-.collapsible-trigger,
-.collapsible-body {
+.collapsible-trigger {
   @extend .px-0;
+}
+
+.collapsible-body {
+  @extend .p-0;
 }

--- a/src/components/common/layout/SidebarBlock.jsx
+++ b/src/components/common/layout/SidebarBlock.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const SidebarBlock = props => (
   <div className={props.className}>
-    {props.title && <h2 className="mb-2">{props.title}</h2>}
+    {props.title && <h4 className="mb-2">{props.title}</h4>}
     {props.children}
   </div>
 );

--- a/src/components/enterprise/dashboard/sidebar/DashboardSidebar.jsx
+++ b/src/components/enterprise/dashboard/sidebar/DashboardSidebar.jsx
@@ -6,6 +6,8 @@ import { LayoutContext, SidebarBlock } from '../../../common/layout';
 import { LoadingSpinner } from '../../../common/loading-spinner';
 import { fetchOffers, Offer } from './offers';
 
+import { isFeatureEnabled } from '../../../../common/features';
+
 class DashboardSidebar extends React.Component {
   static contextType = LayoutContext;
 
@@ -57,32 +59,31 @@ class DashboardSidebar extends React.Component {
     const { pageContext: { enterpriseName } } = this.context;
     const {
       offers,
-      isLoading,
+      isOffersLoading,
     } = this.props;
     return (
       <>
-        <SidebarBlock title={`Learning Benefits from ${enterpriseName}`} className="mb-5">
-          {isLoading && (
-            <div className="mb-5">
-              <LoadingSpinner screenReaderText={`loading learning benefits for ${enterpriseName}`} />
-            </div>
-          )}
-          {this.renderOffers(offers)}
-        </SidebarBlock>
-        <SidebarBlock className="mb-5">
-          <div className="mt-5">
-            <h5>Need help?</h5>
-            <p>
-              For technical support, visit the
-              {' '}
-              <a href="https://support.edx.org/hc/en-us">edX Help Center</a>.
-            </p>
-            <p>
-              To request more benefits or specific courses,
-              {' '}
-              {this.renderLearningCoordinatorHelpText()}.
-            </p>
-          </div>
+        {isFeatureEnabled('enterprise_offers') && (
+          <SidebarBlock title={`Learning Benefits from ${enterpriseName}`} className="mb-5">
+            {isOffersLoading && (
+              <div className="mb-5">
+                <LoadingSpinner screenReaderText={`loading learning benefits for ${enterpriseName}`} />
+              </div>
+            )}
+            {this.renderOffers(offers)}
+          </SidebarBlock>
+        )}
+        <SidebarBlock title="Need help?" className="mb-5">
+          <p>
+            For technical support, visit the
+            {' '}
+            <a href="https://support.edx.org/hc/en-us">edX Help Center</a>.
+          </p>
+          <p>
+            To request more benefits or specific courses,
+            {' '}
+            {this.renderLearningCoordinatorHelpText()}.
+          </p>
         </SidebarBlock>
       </>
     );
@@ -91,13 +92,13 @@ class DashboardSidebar extends React.Component {
 
 DashboardSidebar.defaultProps = {
   fetchOffers: null,
-  isLoading: false,
+  isOffersLoading: false,
   offers: [],
 };
 
 DashboardSidebar.propTypes = {
   fetchOffers: PropTypes.func,
-  isLoading: PropTypes.bool,
+  isOffersLoading: PropTypes.bool,
   offers: PropTypes.arrayOf(PropTypes.shape({
     usageType: PropTypes.string,
     benefitValue: PropTypes.number,
@@ -108,7 +109,7 @@ DashboardSidebar.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  isLoading: state.offers.loading,
+  isOffersLoading: state.offers.loading,
   offers: state.offers.offers,
 });
 

--- a/src/components/masters/program/sidebar/tests/__snapshots__/ProgramSidebar.test.jsx.snap
+++ b/src/components/masters/program/sidebar/tests/__snapshots__/ProgramSidebar.test.jsx.snap
@@ -2,11 +2,11 @@
 
 exports[`<ProgramSidebar /> renders correctly 1`] = `
 <div>
-  <h2
+  <h4
     className="mb-2"
   >
     Get Technical Support
-  </h2>
+  </h4>
   <p>
     <a
       href="https://support.edx.org/hc/en-us"
@@ -43,11 +43,11 @@ Array [
   <div
     className="mb-5"
   >
-    <h2
+    <h4
       className="mb-2"
     >
       Program Documents
-    </h2>
+    </h4>
     <nav
       aria-label="program documents"
     >
@@ -146,11 +146,11 @@ Array [
     </nav>
   </div>,
   <div>
-    <h2
+    <h4
       className="mb-2"
     >
       Get Technical Support
-    </h2>
+    </h4>
     <p>
       <a
         href="https://support.edx.org/hc/en-us"


### PR DESCRIPTION
This PR hides the offers section in the Enterprise dashboard sidebar unless an `enterprise_offers` feature flag is enabled via the query parameter, e.g. "?features=enterprise_offers".

I also changed the `<h3>` and `<h5>` in the sidebar to be `<h4>`. This makes all sidebar block headings the same size (consistency!) and has slightly less visual importance than the course cards.