### PR TITLE
Remove pageType conditional in favor of programUUID check

### DIFF
--- a/src/components/common/course-enrollments/data/actions.js
+++ b/src/components/common/course-enrollments/data/actions.js
@@ -47,7 +47,7 @@ export const updateIsMarkCourseCompleteSuccess = ({ isSuccess }) => ({
 
 const transformCourseEnrollmentsResponse = ({ responseData, options }) => {
   const camelCaseResponseData = camelCaseObject(responseData);
-  if (options.pageType === 'pages.ProgramPage') {
+  if (options.programUUID) {
     return camelCaseResponseData.courseRuns;
   }
   return [...camelCaseResponseData];


### PR DESCRIPTION
This PR addresses [EDUCATOR-4688](https://openedx.atlassian.net/browse/EDUCATOR-4688). The issue was related to the recent refactor that removed the conditional checks based on page type (ProgramPage, EnterprisePage) throughout the app for both masters/enterprise, but missed one spot where this conditional check happens: https://github.com/edx/frontend-app-learner-portal/blob/master/src/components/common/course-enrollments/data/actions.js#L50.

The `options` passed into this function no longer has a `pageType` key but the code was relying on it to be able to get the `course_runs` data from the program enrollments overview endpoint response.  Instead, we can know if the call if for a program since the options object passed into the `transformCourseEnrollmentsResponse` function contains a `programUUID` key.